### PR TITLE
Adding parameters for decls and referencs

### DIFF
--- a/grammars/lmlangmap/AbstractSyntax.sv
+++ b/grammars/lmlangmap/AbstractSyntax.sv
@@ -16,12 +16,12 @@ global pp_tab_spacing :: String = "";
 
 -- Types used in scope graphs for this language example
 type Target_type = Decorated Exp;
-type Graph_type = Graph<Target_type>;
-type Scope_type = Scope<Target_type>;
-type Decl_type = Declaration<Target_type>;
-type Usage_type = Usage<Target_type>;
-type Error_type = Error<Target_type>;
-type Path_type = Path<Target_type>;
+type Graph_type = Graph;
+type Scope_type = Scope;
+type Decl_type = Declaration;
+type Usage_type = Usage;
+type Error_type = Error;
+type Path_type = Path;
 
 -- Attributes used in printing an AST
 synthesized attribute pp::String occurs on Program, DeclList, Decl, Qid, Exp, 

--- a/grammars/lmlangmap/AbstractSyntax.sv
+++ b/grammars/lmlangmap/AbstractSyntax.sv
@@ -83,7 +83,8 @@ top::Program ::= list::DeclList
     list.syn_decls,
     list.syn_refs,
     list.syn_imports,
-    list.syn_scopes
+    list.syn_scopes,
+    nothing()
   );
   
   local attribute init_graph::Graph_type = cons_graph(init_scope::list.syn_all_scopes);
@@ -194,7 +195,8 @@ top::Decl ::= id::ID_t list::DeclList
     list.syn_decls,
     list.syn_refs,
     list.syn_imports,
-    list.syn_scopes
+    list.syn_scopes,
+    just(init_decl)
   );
 
   local attribute init_decl::Decl_type = cons_decl(
@@ -327,20 +329,21 @@ top::Exp ::= list::BindListSeq exp::Exp
 abstract production bindlist_list_seq
 top::BindListSeq ::= id::ID_t exp::Exp list::BindListSeq
 {
+  local attribute init_scope::Scope_type = cons_scope (
+    just(top.inh_scope),
+    [init_decl],
+    list.syn_refs,
+    list.syn_imports,
+    list.syn_scopes,
+    nothing()
+  );
+
   local attribute init_decl::Decl_type = cons_decl (
     id.lexeme,
     top.inh_scope,
     nothing(),
     id.line,
     id.column
-  );
-
-  local attribute init_scope::Scope_type = cons_scope (
-    just(top.inh_scope),
-    [init_decl],
-    list.syn_refs,
-    list.syn_imports,
-    list.syn_scopes
   );
   
   top.syn_decls = exp.syn_decls;
@@ -399,7 +402,8 @@ top::Exp ::= list::BindListRec exp::Exp
     list.syn_decls ++ exp.syn_decls,
     list.syn_refs ++ exp.syn_refs,
     list.syn_imports ++ exp.syn_imports,
-    [] -- TODO
+    [], -- TODO
+    nothing()
   );
 
   top.syn_decls = [];
@@ -482,7 +486,8 @@ top::Exp ::= list::BindListPar exp::Exp
     list.syn_decls_two ++ exp.syn_decls,
     list.syn_refs_two ++ exp.syn_refs,
     list.syn_imports_two ++ exp.syn_imports,
-    [] -- TODO
+    [], -- TODO
+    nothing()
   );
 
   top.syn_decls = list.syn_decls;
@@ -568,20 +573,21 @@ top::BindListPar ::=
 abstract production exp_funfix
 top::Exp ::= id::ID_t exp::Exp
 {
+  local attribute init_scope::Scope_type = cons_scope (
+    just(top.inh_scope),
+    exp.syn_decls ++ [init_decl],
+    exp.syn_refs,
+    exp.syn_imports,
+    exp.syn_scopes,
+    nothing()
+  );
+
   local attribute init_decl::Decl_type = cons_decl (
     id.lexeme,
     top.inh_scope,
     nothing(),
     id.line,
     id.column
-  );
-
-  local attribute init_scope::Scope_type = cons_scope (
-    just(top.inh_scope),
-    exp.syn_decls ++ [init_decl],
-    exp.syn_refs,
-    exp.syn_imports,
-    exp.syn_scopes
   );
 
   top.syn_decls = [];
@@ -698,19 +704,20 @@ synthesized attribute syn_last_ref::Decorated Usage_type occurs on Qid;
 abstract production qid_list
 top::Qid ::= id::ID_t qid::Qid
 {
-  local attribute init_usage::Usage_type = cons_usage ( -- rqid
-    id.lexeme,
-    top.inh_scope,
-    id.line,
-    id.column
-  );
-
   local attribute init_scope::Scope_type = cons_scope (
     nothing(),
     qid.syn_decls,
     qid.syn_refs,
     qid.syn_imports ++ [init_usage],
-    qid.syn_scopes
+    qid.syn_scopes,
+    nothing()
+  );
+  
+  local attribute init_usage::Usage_type = cons_usage ( -- rqid
+    id.lexeme,
+    top.inh_scope,
+    id.line,
+    id.column
   );
 
   top.syn_decls = [];

--- a/grammars/lmlangmap/AbstractSyntax.sv
+++ b/grammars/lmlangmap/AbstractSyntax.sv
@@ -757,22 +757,6 @@ top::Qid ::= id::ID_t
   top.syn_all_scopes = [];
   top.syn_scopes = [];
 
-  -- error and path handling
-
-  --local attribute resolved::[Decorated Decl_type] = resolve([], init_import);
-
-  {-
-  local attribute no_decl::Error_type = no_declaration_found(init_import);
-  local attribute mul_decl::Error_type = multiple_declarations_found(init_import);
-  
-  top.errors = if (length(init_import.resolutions) < 1) then
-    [no_decl]
-  else if (length(init_import.resolutions) > 1) then
-    [mul_decl]
-  else
-    [];
-  -}
-
   local attribute fst_path::Path_type = cons_path(init_import, head(init_import.resolutions)); -- TODO: in case of errors print some paths anyway
   top.paths = [fst_path];
 

--- a/grammars/lmlangmap/AbstractSyntax.sv
+++ b/grammars/lmlangmap/AbstractSyntax.sv
@@ -15,7 +15,6 @@ global pp_line_spcing :: String = "";
 global pp_tab_spacing :: String = ""; 
 
 -- Types used in scope graphs for this language example
-type Target_type = Decorated Exp;
 type Graph_type = Graph;
 type Scope_type = Scope;
 type Decl_type = Declaration;

--- a/grammars/lmlangmap/AbstractSyntax.sv
+++ b/grammars/lmlangmap/AbstractSyntax.sv
@@ -69,8 +69,6 @@ synthesized attribute syn_iqid_import::(String, Decorated Usage_type) occurs on 
 synthesized attribute ret_scope::Decorated Scope_type occurs on BindListSeq;
 
 -- The lists of errors and paths found in scope graph resolution
-synthesized attribute errors::[Decorated Error_type] occurs on Program, DeclList, Decl, Qid, Exp, 
-  BindListSeq, BindListRec, BindListPar;
 synthesized attribute paths::[Decorated Path_type] occurs on Program, DeclList, Decl, Qid, Exp, 
   BindListSeq, BindListRec, BindListPar;
 
@@ -116,7 +114,6 @@ top::Program ::= list::DeclList
       -> errors ++ (if !snd(decl_pair) then [  decorate_err(fst(decl_pair))  ] else []) -- had to use decorate_err function instead of declaration_unused constructor?? replace with "decorate foo() with {}"?
   ), [], mapped);
   -}
-  top.errors = list.errors; -- make above warnings instead? (words instead of "parse failure")
   top.paths = list.paths;
   
   -- pretty printing
@@ -159,7 +156,6 @@ top::DeclList ::= decl::Decl list::DeclList
   list.inh_scope = top.inh_scope;
 
   -- error and path handling
-  top.errors = decl.errors ++ list.errors;
   top.paths = decl.paths ++ list.paths;
 
   -- pretty printing
@@ -180,7 +176,6 @@ top::DeclList ::=
   top.syn_scopes = []; -- ADD
 
   -- error and path handling
-  top.errors = [];
   top.paths = [];
 
   -- pretty printing
@@ -221,7 +216,6 @@ top::Decl ::= id::ID_t list::DeclList
   list.inh_scope = init_scope;
 
   -- error and path handling
-  top.errors = list.errors;
   top.paths = list.paths;
 
   -- pretty printing
@@ -244,7 +238,6 @@ top::Decl ::= qid::Qid
   qid.inh_scope_two = top.inh_scope;
 
   -- error and path handling
-  top.errors = qid.errors;
   top.paths = qid.paths;
 
   -- pretty printing
@@ -273,7 +266,6 @@ top::Decl ::= id::ID_t exp::Exp
   exp.inh_scope = top.inh_scope;
 
   -- error and path handling
-  top.errors = exp.errors;
   top.paths = exp.paths;
 
   -- pretty printing
@@ -295,7 +287,6 @@ top::Decl ::= exp::Exp
   exp.inh_scope = top.inh_scope;
 
   -- error and path handling
-  top.errors = exp.errors;
   top.paths = exp.paths;
 
   -- pretty printing
@@ -326,7 +317,6 @@ top::Exp ::= list::BindListSeq exp::Exp
   exp.inh_scope = list.ret_scope;
   
   -- error and path handling
-  top.errors = list.errors ++ exp.errors;
   top.paths = list.paths ++ exp.paths;
 
   -- pretty printing
@@ -370,7 +360,6 @@ top::BindListSeq ::= id::ID_t exp::Exp list::BindListSeq
   list.inh_imports = top.inh_imports;
 
   -- error and path handling
-  top.errors = exp.errors ++ list.errors;
   top.paths = exp.paths ++ list.paths;
 
   -- pretty printing
@@ -392,7 +381,6 @@ top::BindListSeq ::=
   top.syn_scopes = [];
 
   -- error and path handling
-  top.errors = [];
   top.paths = [];
 
   -- pretty printing
@@ -426,7 +414,6 @@ top::Exp ::= list::BindListRec exp::Exp
   exp.inh_scope = init_scope;
 
   -- error and path handling
-  top.errors = list.errors ++ exp.errors;
   top.paths = list.paths ++ exp.paths;
 
   -- pretty printing
@@ -458,7 +445,6 @@ top::BindListRec ::= id::ID_t exp::Exp list::BindListRec
   exp.inh_scope = top.inh_scope;
 
   -- error and path handling
-  top.errors = exp.errors ++ list.errors;
   top.paths = exp.paths ++ list.paths;
 
   -- pretty printing
@@ -478,7 +464,6 @@ top::BindListRec ::=
   top.syn_all_scopes = [];
 
   -- error and path handling
-  top.errors = [];
   top.paths = [];
 
   -- pretty printing
@@ -513,7 +498,6 @@ top::Exp ::= list::BindListPar exp::Exp
   exp.inh_scope = init_scope;
 
   -- error and path handling
-  top.errors = list.errors ++ exp.errors;
   top.paths = list.paths ++ exp.paths;
 
   -- pretty printing
@@ -549,7 +533,6 @@ top::BindListPar ::= id::ID_t exp::Exp list::BindListPar
   list.inh_scope_two = top.inh_scope_two;
 
   -- error and path handling
-  top.errors = exp.errors ++ list.errors;
   top.paths = exp.paths ++ list.paths;
 
   -- pretty printing
@@ -572,7 +555,6 @@ top::BindListPar ::=
   top.syn_all_scopes = [];
 
   -- error and path handling
-  top.errors = [];
   top.paths = [];
   
   -- pretty printing
@@ -613,7 +595,6 @@ top::Exp ::= id::ID_t exp::Exp
   exp.inh_scope = init_scope;
 
   -- error and path handling
-  top.errors = exp.errors;
   top.paths = exp.paths;
 
   -- pretty printing
@@ -637,7 +618,6 @@ top::Exp ::= expLeft::Exp expRight::Exp
   expRight.inh_scope = top.inh_scope;
 
   -- error and path handling
-  top.errors = expLeft.errors ++ expRight.errors;
   top.paths = expLeft.paths ++ expRight.paths;
 
   -- pretty printing
@@ -662,7 +642,6 @@ top::Exp ::= expLeft::Exp expRight::Exp
   expRight.inh_scope = top.inh_scope;
 
   -- error and path handling
-  top.errors = expLeft.errors ++ expRight.errors;
   top.paths = expLeft.paths ++ expRight.paths;
 
   -- pretty printing
@@ -685,7 +664,6 @@ top::Exp ::= qid::Qid
   qid.inh_scope = top.inh_scope;
 
   -- error and path handling
-  top.errors = qid.errors;
   top.paths = qid.paths;
 
   -- pretty printing
@@ -704,7 +682,6 @@ top::Exp ::= val::Int_t
   top.syn_scopes = [];
 
   -- error and path handling
-  top.errors = [];
   top.paths = [];
 
   -- pretty printing
@@ -749,7 +726,6 @@ top::Qid ::= id::ID_t qid::Qid
   qid.inh_scope_two = top.inh_scope_two;
   
   -- error and path handling
-  top.errors = qid.errors;
   top.paths = qid.paths;
 
   -- pretty printing
@@ -787,6 +763,7 @@ top::Qid ::= id::ID_t
 
   --local attribute resolved::[Decorated Decl_type] = resolve([], init_import);
 
+  {-
   local attribute no_decl::Error_type = no_declaration_found(init_import);
   local attribute mul_decl::Error_type = multiple_declarations_found(init_import);
   
@@ -796,6 +773,7 @@ top::Qid ::= id::ID_t
     [mul_decl]
   else
     [];
+  -}
 
   local attribute fst_path::Path_type = cons_path(init_import, head(init_import.resolutions)); -- TODO: in case of errors print some paths anyway
   top.paths = [fst_path];

--- a/grammars/lmlangmap/AbstractSyntax.sv
+++ b/grammars/lmlangmap/AbstractSyntax.sv
@@ -72,7 +72,6 @@ synthesized attribute ret_scope::Decorated Scope_type occurs on BindListSeq;
 synthesized attribute paths::[Decorated Path_type] occurs on Program, DeclList, Decl, Qid, Exp, 
   BindListSeq, BindListRec, BindListPar;
 
-
 ------------------------------------------------------------
 ---- Program root
 ------------------------------------------------------------

--- a/grammars/lmlangmap/AbstractSyntax.sv
+++ b/grammars/lmlangmap/AbstractSyntax.sv
@@ -42,27 +42,27 @@ synthesized attribute syn_all_scopes::[Decorated Scope_type] occurs on DeclList,
 -- Information required for constructing scope nodes with references, declarations and imports
 -- Sub-expressions can synthesize each of these, which must be given to the enclosing scope
 -- Only the binding list of parrallel let expressions use two synthesized attributes for each
-synthesized attribute syn_decls::[(String, Decorated Decl_type)] occurs on DeclList, 
+synthesized attribute syn_decls::[Decorated Decl_type] occurs on DeclList, 
   Decl, Qid, Exp,BindListSeq, BindListRec, BindListPar;
-synthesized attribute syn_refs::[(String, Decorated Usage_type)] occurs on DeclList, 
+synthesized attribute syn_refs::[Decorated Usage_type] occurs on DeclList, 
   Decl, Qid, Exp, BindListSeq, BindListRec, BindListPar;
-synthesized attribute syn_imports::[(String, Decorated Usage_type)] occurs on DeclList, 
+synthesized attribute syn_imports::[Decorated Usage_type] occurs on DeclList, 
   Decl, Qid, Exp, BindListSeq, BindListRec, BindListPar;
-synthesized attribute syn_decls_two::[(String, Decorated Decl_type)] occurs on BindListPar;
-synthesized attribute syn_refs_two::[(String, Decorated Usage_type)] occurs on BindListPar;
-synthesized attribute syn_imports_two::[(String, Decorated Usage_type)] occurs on BindListPar;
+synthesized attribute syn_decls_two::[Decorated Decl_type] occurs on BindListPar;
+synthesized attribute syn_refs_two::[Decorated Usage_type] occurs on BindListPar;
+synthesized attribute syn_imports_two::[Decorated Usage_type] occurs on BindListPar;
 
 -- For double-edged arrow between parent and child scopes
 synthesized attribute syn_scopes::[Decorated Scope_type] occurs on DeclList, Decl, Qid, Exp, 
   BindListSeq, BindListRec, BindListPar;
 
 -- Inherited declarations, references and imports, used by the binding lists of sequential let expressions
-inherited attribute inh_decls::[(String, Decorated Decl_type)] occurs on BindListSeq;
-inherited attribute inh_refs::[(String, Decorated Usage_type)] occurs on BindListSeq;
-inherited attribute inh_imports::[(String, Decorated Usage_type)] occurs on BindListSeq;
+inherited attribute inh_decls::[Decorated Decl_type] occurs on BindListSeq;
+inherited attribute inh_refs::[Decorated Usage_type] occurs on BindListSeq;
+inherited attribute inh_imports::[Decorated Usage_type] occurs on BindListSeq;
 
 -- The import synthesized in the "iqid" construct of the scope graph construction algorithm for this language example
-synthesized attribute syn_iqid_import::(String, Decorated Usage_type) occurs on Qid;
+synthesized attribute syn_iqid_import::Decorated Usage_type occurs on Qid;
 
 -- The scope returned by the binding list construct of a sequential let expression
 synthesized attribute ret_scope::Decorated Scope_type occurs on BindListSeq;
@@ -83,15 +83,15 @@ top::Program ::= list::DeclList
     list.syn_decls,
     list.syn_refs,
     list.syn_imports,
-    list.syn_scopes -- ADD
+    list.syn_scopes
   );
   
-  local attribute init_graph::Graph_type = cons_graph(init_scope::list.syn_all_scopes, list.paths);
+  local attribute init_graph::Graph_type = cons_graph(init_scope::list.syn_all_scopes);
   top.syn_graph = init_graph; -- simply substituting cons_graph(...) here does not work
 
   list.inh_scope = init_scope;
 
-  -- error and path handling
+  -- path handling
   {-
   -- collect all of the declarations that some reference is resolved to
   local attribute used_decls::[Decorated Decl_type] = map((\path::Decorated Path_type -> path.final), list.paths);
@@ -114,7 +114,7 @@ top::Program ::= list::DeclList
   -}
   top.paths = list.paths;
   
-  -- pretty printing
+  -- ast printing
   top.pp = "prog(" ++ list.pp ++ ")";
   list.tab_level = pp_tab_spacing;
 
@@ -147,16 +147,16 @@ top::DeclList ::= decl::Decl list::DeclList
   top.syn_refs = decl.syn_refs ++ list.syn_refs;
   top.syn_imports = decl.syn_imports ++ list.syn_imports;
   top.syn_all_scopes = decl.syn_all_scopes ++ list.syn_all_scopes;
-  top.syn_scopes = decl.syn_scopes ++ list.syn_scopes; -- ADD
+  top.syn_scopes = decl.syn_scopes ++ list.syn_scopes;
 
   decl.inh_scope = top.inh_scope;
 
   list.inh_scope = top.inh_scope;
 
-  -- error and path handling
+  -- path handling
   top.paths = decl.paths ++ list.paths;
 
-  -- pretty printing
+  -- ast printing
   top.pp = top.tab_level ++ "decllist_list(" ++ decl.pp ++ "," 
     ++ list.pp ++ "" ++ top.tab_level ++ ")";
   decl.tab_level = pp_tab_spacing ++ top.tab_level;
@@ -171,12 +171,12 @@ top::DeclList ::=
   top.syn_refs = [];
   top.syn_imports = [];
   top.syn_all_scopes = [];
-  top.syn_scopes = []; -- ADD
+  top.syn_scopes = [];
 
-  -- error and path handling
+  -- path handling
   top.paths = [];
 
-  -- pretty printing
+  -- ast printing
   top.pp = top.tab_level ++ "decllist_nothing()";
 
 }
@@ -194,7 +194,7 @@ top::Decl ::= id::ID_t list::DeclList
     list.syn_decls,
     list.syn_refs,
     list.syn_imports,
-    list.syn_scopes -- ADD
+    list.syn_scopes
   );
 
   local attribute init_decl::Decl_type = cons_decl(
@@ -205,18 +205,18 @@ top::Decl ::= id::ID_t list::DeclList
     id.column
   );
 
-  top.syn_decls = [(id.lexeme, init_decl)];
+  top.syn_decls = [init_decl];
   top.syn_refs = [];
   top.syn_imports = [];
   top.syn_all_scopes = [init_scope] ++ list.syn_all_scopes;
-  top.syn_scopes = [init_scope]; -- ADD
+  top.syn_scopes = [init_scope];
 
   list.inh_scope = init_scope;
 
-  -- error and path handling
+  -- path handling
   top.paths = list.paths;
 
-  -- pretty printing
+  -- ast printing
   top.pp = top.tab_level ++ "decl_module(" ++ pp_tab_spacing ++ top.tab_level ++ id.lexeme ++ "," 
     ++ list.pp ++ "" ++ top.tab_level ++ ")";
   list.tab_level = pp_tab_spacing ++ top.tab_level;
@@ -230,15 +230,15 @@ top::Decl ::= qid::Qid
   top.syn_refs = qid.syn_refs;
   top.syn_imports = qid.syn_imports ++ [qid.syn_iqid_import]; -- rqid followed by iqid in construction rules
   top.syn_all_scopes = qid.syn_all_scopes;
-  top.syn_scopes = qid.syn_scopes; -- ADD
+  top.syn_scopes = qid.syn_scopes;
 
   qid.inh_scope = top.inh_scope;
   qid.inh_scope_two = top.inh_scope;
 
-  -- error and path handling
+  -- path handling
   top.paths = qid.paths;
 
-  -- pretty printing
+  -- ast printing
   top.pp = top.tab_level ++ "decl_import(" ++ qid.pp ++ "" ++ top.tab_level ++ ")";
   qid.tab_level = top.tab_level ++ pp_tab_spacing;
 
@@ -255,18 +255,18 @@ top::Decl ::= id::ID_t exp::Exp
     id.column
   );
 
-  top.syn_decls = [(id.lexeme, init_decl)] ++ exp.syn_decls;
+  top.syn_decls = [init_decl] ++ exp.syn_decls;
   top.syn_refs = exp.syn_refs;
   top.syn_imports = exp.syn_imports;
   top.syn_all_scopes = exp.syn_all_scopes;
-  top.syn_scopes = exp.syn_scopes; -- ADD
+  top.syn_scopes = exp.syn_scopes;
 
   exp.inh_scope = top.inh_scope;
 
-  -- error and path handling
+  -- path handling
   top.paths = exp.paths;
 
-  -- pretty printing
+  -- ast printing
   top.pp = top.tab_level ++ "decl_def(" ++ top.tab_level ++ pp_tab_spacing ++ id.lexeme ++ ","
     ++ exp.pp ++ "" ++ top.tab_level ++ ")";
   exp.tab_level = pp_tab_spacing ++ top.tab_level;
@@ -284,10 +284,10 @@ top::Decl ::= exp::Exp
 
   exp.inh_scope = top.inh_scope;
 
-  -- error and path handling
+  -- path handling
   top.paths = exp.paths;
 
-  -- pretty printing
+  -- ast printing
   top.pp = top.tab_level ++ "decl_exp(" ++ exp.pp ++ "" ++ top.tab_level ++ ")";
   exp.tab_level = pp_tab_spacing ++ top.tab_level;
 
@@ -305,7 +305,7 @@ top::Exp ::= list::BindListSeq exp::Exp
   top.syn_refs = list.syn_refs;
   top.syn_imports = list.syn_imports;
   top.syn_all_scopes = list.syn_all_scopes ++ exp.syn_all_scopes;
-  top.syn_scopes = list.syn_scopes ++ exp.syn_scopes; -- ADD
+  top.syn_scopes = list.syn_scopes ++ exp.syn_scopes;
 
   list.inh_scope = top.inh_scope;
   list.inh_decls = exp.syn_decls; -- bringing up exp's decls/refs/imports to give to the final scope in the binding list
@@ -314,10 +314,10 @@ top::Exp ::= list::BindListSeq exp::Exp
 
   exp.inh_scope = list.ret_scope;
   
-  -- error and path handling
+  -- path handling
   top.paths = list.paths ++ exp.paths;
 
-  -- pretty printing
+  -- ast printing
   top.pp = top.tab_level ++ "exp_let(" ++ list.pp ++ "," ++ exp.pp ++ "" ++ top.tab_level ++ ")";
   list.tab_level = pp_tab_spacing ++ top.tab_level;
   exp.tab_level = pp_tab_spacing ++ top.tab_level;
@@ -337,10 +337,10 @@ top::BindListSeq ::= id::ID_t exp::Exp list::BindListSeq
 
   local attribute init_scope::Scope_type = cons_scope (
     just(top.inh_scope),
-    [(id.lexeme, init_decl)],
+    [init_decl],
     list.syn_refs,
     list.syn_imports,
-    list.syn_scopes -- ADD
+    list.syn_scopes
   );
   
   top.syn_decls = exp.syn_decls;
@@ -348,7 +348,7 @@ top::BindListSeq ::= id::ID_t exp::Exp list::BindListSeq
   top.syn_imports = exp.syn_imports;
   top.syn_all_scopes = [init_scope] ++ exp.syn_all_scopes ++ list.syn_all_scopes;
   top.ret_scope = list.ret_scope;
-  top.syn_scopes = [init_scope]; -- ADD
+  top.syn_scopes = [init_scope];
 
   exp.inh_scope = top.inh_scope;
 
@@ -357,10 +357,10 @@ top::BindListSeq ::= id::ID_t exp::Exp list::BindListSeq
   list.inh_refs = top.inh_refs;
   list.inh_imports = top.inh_imports;
 
-  -- error and path handling
+  -- path handling
   top.paths = exp.paths ++ list.paths;
 
-  -- pretty printing
+  -- ast printing
   top.pp = top.tab_level ++ "bindlist_list_seq(" ++ top.tab_level ++ pp_tab_spacing ++ 
     id.lexeme ++ "," ++ exp.pp ++ "," ++ list.pp ++ "" ++ top.tab_level ++ ")";
   exp.tab_level = pp_tab_spacing ++ top.tab_level;
@@ -378,10 +378,10 @@ top::BindListSeq ::=
   top.syn_all_scopes = [];
   top.syn_scopes = [];
 
-  -- error and path handling
+  -- path handling
   top.paths = [];
 
-  -- pretty printing
+  -- ast printing
   top.pp = top.tab_level ++ "bindlist_nothing_seq()";
 
 }
@@ -411,10 +411,10 @@ top::Exp ::= list::BindListRec exp::Exp
 
   exp.inh_scope = init_scope;
 
-  -- error and path handling
+  -- path handling
   top.paths = list.paths ++ exp.paths;
 
-  -- pretty printing
+  -- ast printing
   top.pp = top.tab_level ++ "exp_letrec(" ++ list.pp ++ "," 
     ++ exp.pp ++ "" ++ top.tab_level ++ ")";
   list.tab_level = pp_tab_spacing ++ top.tab_level;
@@ -433,7 +433,7 @@ top::BindListRec ::= id::ID_t exp::Exp list::BindListRec
     id.column
   );
 
-  top.syn_decls = exp.syn_decls ++ list.syn_decls ++ [(id.lexeme, init_decl)];
+  top.syn_decls = exp.syn_decls ++ list.syn_decls ++ [init_decl];
   top.syn_refs = exp.syn_refs ++ list.syn_refs;
   top.syn_imports = exp.syn_imports ++ list.syn_imports;
   top.syn_all_scopes = exp.syn_all_scopes ++ list.syn_all_scopes;
@@ -442,10 +442,10 @@ top::BindListRec ::= id::ID_t exp::Exp list::BindListRec
 
   exp.inh_scope = top.inh_scope;
 
-  -- error and path handling
+  -- path handling
   top.paths = exp.paths ++ list.paths;
 
-  -- pretty printing
+  -- ast printing
   top.pp = top.tab_level ++ "bindlist_list_rec(" ++ top.tab_level ++ pp_tab_spacing 
     ++ id.lexeme ++ " = " ++ exp.pp ++ "," ++ list.pp ++ "" ++ top.tab_level ++ ")";
   exp.tab_level = pp_tab_spacing ++ top.tab_level;
@@ -461,10 +461,10 @@ top::BindListRec ::=
   top.syn_imports = [];
   top.syn_all_scopes = [];
 
-  -- error and path handling
+  -- path handling
   top.paths = [];
 
-  -- pretty printing
+  -- ast printing
   top.pp = top.tab_level ++ "bindlist_nothing_rec()";
 
 }
@@ -495,10 +495,10 @@ top::Exp ::= list::BindListPar exp::Exp
 
   exp.inh_scope = init_scope;
 
-  -- error and path handling
+  -- path handling
   top.paths = list.paths ++ exp.paths;
 
-  -- pretty printing
+  -- ast printing
   top.pp = top.tab_level ++ "exp_letpar(" ++ list.pp ++ "," 
     ++ exp.pp ++ "" ++ top.tab_level ++ ")";
   list.tab_level = pp_tab_spacing ++ top.tab_level;
@@ -520,7 +520,7 @@ top::BindListPar ::= id::ID_t exp::Exp list::BindListPar
   top.syn_decls = exp.syn_decls ++ list.syn_decls;
   top.syn_refs = exp.syn_refs ++ list.syn_refs;
   top.syn_imports = exp.syn_imports ++ list.syn_imports;
-  top.syn_decls_two = list.syn_decls_two ++ [(id.lexeme, init_decl)];
+  top.syn_decls_two = list.syn_decls_two ++ [init_decl];
   top.syn_refs_two = list.syn_refs_two;
   top.syn_imports_two = list.syn_imports_two;
   top.syn_all_scopes = exp.syn_all_scopes ++ list.syn_all_scopes;
@@ -530,10 +530,10 @@ top::BindListPar ::= id::ID_t exp::Exp list::BindListPar
   list.inh_scope = top.inh_scope;
   list.inh_scope_two = top.inh_scope_two;
 
-  -- error and path handling
+  -- path handling
   top.paths = exp.paths ++ list.paths;
 
-  -- pretty printing
+  -- ast printing
   top.pp = top.tab_level ++ "bindlist_list_par(" ++ top.tab_level ++ pp_tab_spacing 
     ++ id.lexeme ++ " = " ++ exp.pp ++ "," ++ list.pp ++ "" ++ top.tab_level ++ ")";
   exp.tab_level = pp_tab_spacing ++ top.tab_level;
@@ -552,10 +552,10 @@ top::BindListPar ::=
   top.syn_imports_two = [];
   top.syn_all_scopes = [];
 
-  -- error and path handling
+  -- path handling
   top.paths = [];
   
-  -- pretty printing
+  -- ast printing
   top.pp = top.tab_level ++ "bindlist_nothing_par()";
 
 }
@@ -578,24 +578,24 @@ top::Exp ::= id::ID_t exp::Exp
 
   local attribute init_scope::Scope_type = cons_scope (
     just(top.inh_scope),
-    exp.syn_decls ++ [(id.lexeme, init_decl)],
+    exp.syn_decls ++ [init_decl],
     exp.syn_refs,
     exp.syn_imports,
-    exp.syn_scopes -- ADD
+    exp.syn_scopes
   );
 
   top.syn_decls = [];
   top.syn_refs = [];
   top.syn_imports = [];
   top.syn_all_scopes = [init_scope] ++ exp.syn_all_scopes;
-  top.syn_scopes = [init_scope]; -- ADD
+  top.syn_scopes = [init_scope];
 
   exp.inh_scope = init_scope;
 
-  -- error and path handling
+  -- path handling
   top.paths = exp.paths;
 
-  -- pretty printing
+  -- ast printing
   top.pp = top.tab_level ++ "exp_funfix(" ++ top.tab_level ++ pp_tab_spacing ++ id.lexeme ++ ","
     ++ exp.pp ++ "" ++ top.tab_level ++ ")";
   exp.tab_level = pp_tab_spacing ++ top.tab_level;
@@ -615,10 +615,10 @@ top::Exp ::= expLeft::Exp expRight::Exp
 
   expRight.inh_scope = top.inh_scope;
 
-  -- error and path handling
+  -- path handling
   top.paths = expLeft.paths ++ expRight.paths;
 
-  -- pretty printing
+  -- ast printing
   top.pp = top.tab_level ++ "exp_plus(" ++ expLeft.pp ++ "," 
     ++ expRight.pp ++ "" ++ top.tab_level ++ ")";
   expLeft.tab_level = pp_tab_spacing ++ top.tab_level;
@@ -639,10 +639,10 @@ top::Exp ::= expLeft::Exp expRight::Exp
 
   expRight.inh_scope = top.inh_scope;
 
-  -- error and path handling
+  -- path handling
   top.paths = expLeft.paths ++ expRight.paths;
 
-  -- pretty printing
+  -- ast printing
   top.pp = top.tab_level ++ "exp_app(" ++ expLeft.pp ++ "," 
     ++ expRight.pp ++ "" ++ top.tab_level ++ ")";
   expLeft.tab_level = pp_tab_spacing ++ top.tab_level;
@@ -661,10 +661,10 @@ top::Exp ::= qid::Qid
 
   qid.inh_scope = top.inh_scope;
 
-  -- error and path handling
+  -- path handling
   top.paths = qid.paths;
 
-  -- pretty printing
+  -- ast printing
   top.pp = top.tab_level ++ "exp_qid(" ++ qid.pp ++ "" ++ top.tab_level ++ ")";
   qid.tab_level = pp_tab_spacing ++ top.tab_level;
 
@@ -679,10 +679,10 @@ top::Exp ::= val::Int_t
   top.syn_all_scopes = [];
   top.syn_scopes = [];
 
-  -- error and path handling
+  -- path handling
   top.paths = [];
 
-  -- pretty printing
+  -- ast printing
   top.pp = top.tab_level ++ "exp_int(" ++ top.tab_level ++ pp_tab_spacing 
     ++ val.lexeme ++ "" ++ top.tab_level ++ ")";
 
@@ -709,24 +709,24 @@ top::Qid ::= id::ID_t qid::Qid
     nothing(),
     qid.syn_decls,
     qid.syn_refs,
-    qid.syn_imports ++ [(id.lexeme, init_usage)],
-    qid.syn_scopes -- ADD
+    qid.syn_imports ++ [init_usage],
+    qid.syn_scopes
   );
 
   top.syn_decls = [];
-  top.syn_refs = [(id.lexeme, init_usage)];
+  top.syn_refs = [init_usage];
   top.syn_imports = [];
   top.syn_all_scopes = [init_scope] ++ qid.syn_all_scopes;
   top.syn_iqid_import = qid.syn_iqid_import;
-  top.syn_scopes = []; -- ADD
+  top.syn_scopes = [];
   
   qid.inh_scope = init_scope;
   qid.inh_scope_two = top.inh_scope_two;
   
-  -- error and path handling
+  -- path handling
   top.paths = qid.paths;
 
-  -- pretty printing
+  -- ast printing
   top.pp = top.tab_level ++ "qid_list(" ++ top.tab_level ++ pp_tab_spacing ++ id.lexeme ++ "," 
     ++ qid.pp ++ "" ++ top.tab_level ++ ")";
   qid.tab_level = pp_tab_spacing ++ top.tab_level;
@@ -751,16 +751,16 @@ top::Qid ::= id::ID_t
   );
 
   top.syn_decls = [];
-  top.syn_refs = [(id.lexeme, init_import)];
+  top.syn_refs = [init_import];
   top.syn_imports = [];
-  top.syn_iqid_import = (id.lexeme, init_import_two);
+  top.syn_iqid_import = init_import_two;
   top.syn_all_scopes = [];
   top.syn_scopes = [];
 
   local attribute fst_path::Path_type = cons_path(init_import, head(init_import.resolutions)); -- TODO: in case of errors print some paths anyway
   top.paths = [fst_path];
 
-  -- pretty printing
+  -- ast printing
   top.pp = top.tab_level ++ "qid_single(" ++ top.tab_level ++ pp_tab_spacing ++ id.lexeme ++ "" 
     ++ top.tab_level ++ ")";
 

--- a/grammars/lmlangmap/Main.sv
+++ b/grammars/lmlangmap/Main.sv
@@ -20,17 +20,19 @@ IOVal<Integer> ::= largs::[String] ioin::IOToken
 
   local attribute r::Program = r_cst.ast;
 
-  local attribute print_success :: IOToken;
-  print_success = printT(
-    if (contains("--graph-print", largs)) then "Graph print:\n" ++ graphviz_draw_graph(r.syn_graph, true, true) ++ "\n" else "", ioin);
+  local attribute scope_graph :: Graph_type;
+  scope_graph = new(r.syn_graph);
+
+  --local attribute print_success :: IOToken;
+  --print_success = ;
 
   local attribute print_failure :: IOToken;
-  print_failure = printT(string_errors(r.errors), ioin);
+  print_failure = printT(string_errors(scope_graph.errors), ioin);
 
   local attribute print_resolution_paths :: IOToken;
   print_resolution_paths = systemT("echo '" ++ 
-    graphviz_draw_graph(r.syn_graph, (contains("--show-resolutions", largs)), (contains("--show-children", largs))) ++ 
-    "' | dot -Tsvg > " ++ file_output, print_success).io;
+    graphviz_draw_graph(scope_graph, (contains("--show-resolutions", largs)), (contains("--show-children", largs))) ++ 
+    "' | dot -Tsvg > " ++ file_output, printT(if (contains("--graph-print", largs)) then "Graph print:\n" ++ graphviz_draw_graph(scope_graph, true, true) ++ "\n" else "", ioin)).io;
 
 {-
   local res::IO<Integer> = do {
@@ -56,6 +58,6 @@ IOVal<Integer> ::= largs::[String] ioin::IOToken
 -}
   --return 
       --ioval(if length(r.errors) <= 0 then print_resolution_paths else print_failure, 0);
-      return if length(r.errors) <= 0 then ioval(print_resolution_paths, 0) else ioval(print_failure, -1);
+      return if length(scope_graph.errors) <= 0 then ioval(print_resolution_paths, 0) else ioval(print_resolution_paths, -1);
      -- evalIO (res, ioin) ;
 }

--- a/grammars/lmlangmap/Main.sv
+++ b/grammars/lmlangmap/Main.sv
@@ -25,7 +25,7 @@ IOVal<Integer> ::= largs::[String] ioin::IOToken
     if (contains("--graph-print", largs)) then "Graph print:\n" ++ graphviz_draw_graph(r.syn_graph, true, true) ++ "\n" else "", ioin);
 
   local attribute print_failure :: IOToken;
-  print_failure = printT("Failure!\n" ++ string_errors(r.errors), ioin);
+  print_failure = printT(string_errors(r.errors), ioin);
 
   local attribute print_resolution_paths :: IOToken;
   print_resolution_paths = systemT("echo '" ++ 
@@ -54,7 +54,8 @@ IOVal<Integer> ::= largs::[String] ioin::IOToken
       } ;
     } ;
 -}
-  return 
-      ioval(if length(r.errors) <= 0 then print_resolution_paths else print_failure, 0);
+  --return 
+      --ioval(if length(r.errors) <= 0 then print_resolution_paths else print_failure, 0);
+      return if length(r.errors) <= 0 then ioval(print_resolution_paths, 0) else ioval(print_failure, -1);
      -- evalIO (res, ioin) ;
 }

--- a/grammars/lmlangmap/Main.sv
+++ b/grammars/lmlangmap/Main.sv
@@ -20,7 +20,7 @@ IOVal<Integer> ::= largs::[String] ioin::IOToken
 
   local attribute r::Program = r_cst.ast;
 
-  local attribute scope_graph :: Graph_type;
+  local attribute scope_graph :: Graph;
   scope_graph = new(r.syn_graph);
 
   --local attribute print_success :: IOToken;

--- a/grammars/lmlangmap/Main.sv
+++ b/grammars/lmlangmap/Main.sv
@@ -23,9 +23,6 @@ IOVal<Integer> ::= largs::[String] ioin::IOToken
   local attribute scope_graph :: Graph;
   scope_graph = new(r.syn_graph);
 
-  --local attribute print_success :: IOToken;
-  --print_success = ;
-
   local attribute print_failure :: IOToken;
   print_failure = printT(string_errors(scope_graph.errors), ioin);
 
@@ -58,6 +55,7 @@ IOVal<Integer> ::= largs::[String] ioin::IOToken
 -}
   --return 
       --ioval(if length(r.errors) <= 0 then print_resolution_paths else print_failure, 0);
-      return if length(scope_graph.errors) <= 0 then ioval(print_resolution_paths, 0) else ioval(print_resolution_paths, -1);
+
+  return if length(scope_graph.errors) <= 0 && result.parseSuccess then ioval(print_resolution_paths, 0) else ioval(print_resolution_paths, -1);
      -- evalIO (res, ioin) ;
 }

--- a/grammars/lmlangmap/Main.sv
+++ b/grammars/lmlangmap/Main.sv
@@ -1,6 +1,6 @@
 grammar lmlangmap;
 
-global file_output::String = "scope_graph.svg";
+global file_output::String = "scope_graph_lmlangmap.svg";
 
 parser parse :: Program_c {
     lmlangmap;

--- a/grammars/minijava/AbstractSyntax.sv
+++ b/grammars/minijava/AbstractSyntax.sv
@@ -1,0 +1,103 @@
+grammar minijava;
+
+nonterminal Program;
+nonterminal DeclList;
+nonterminal Decl;
+nonterminal Block;
+nonterminal Extend;
+nonterminal Implement;
+nonterminal Qid;
+
+------------------------------------------------------------
+---- Program
+------------------------------------------------------------
+
+abstract production prog
+top::Program ::= list::DeclList
+{
+
+}
+
+------------------------------------------------------------
+---- Declaration lists
+------------------------------------------------------------
+
+abstract production decllist_list
+top::DeclList ::= decl::Decl list::DeclList
+{
+
+}
+
+abstract production decllist_nothing
+top::DeclList ::=
+{
+
+}
+
+------------------------------------------------------------
+---- Declarations
+------------------------------------------------------------
+
+abstract production decl_class
+top::Decl ::= id::ID_t extend::Extend implement::Implement block::Block
+{
+
+}
+
+------------------------------------------------------------
+---- Block
+------------------------------------------------------------
+
+abstract production block
+top::Block ::=
+{
+
+}
+
+------------------------------------------------------------
+---- Extend
+------------------------------------------------------------
+
+abstract production extendlist_list
+top::Extend ::= qid::Qid
+{
+
+}
+
+abstract production extendlist_nothing
+top::Extend ::=
+{
+
+}
+
+------------------------------------------------------------
+---- Implement
+------------------------------------------------------------
+
+abstract production implementlist_list
+top::Implement ::= qid::Qid
+{
+
+}
+
+abstract production implementlist_nothing
+top::Implement ::=
+{
+
+}
+
+------------------------------------------------------------
+---- Implement
+------------------------------------------------------------
+
+abstract production qid_list
+top::Qid ::= id::ID_t qid::Qid
+{
+
+}
+
+abstract production qid_single
+top::Qid ::= id::ID_t
+{
+
+}

--- a/grammars/minijava/AbstractSyntax.sv
+++ b/grammars/minijava/AbstractSyntax.sv
@@ -25,11 +25,11 @@ synthesized attribute pp::String occurs on Program, DeclList, Decl, Block, Exten
 
 -- Information required for constructing scope nodes with references, declarations and imports
 -- Sub-expressions can synthesize each of these, which must be given to the enclosing scope
-synthesized attribute syn_decls::[(String, Decorated Decl_type)] occurs on DeclList, Decl, Block, 
+synthesized attribute syn_decls::[Decorated Decl_type] occurs on DeclList, Decl, Block, 
   Extend, Implement, QidList, Qid;
-synthesized attribute syn_refs::[(String, Decorated Usage_type)] occurs on DeclList, Decl, Block, 
+synthesized attribute syn_refs::[Decorated Usage_type] occurs on DeclList, Decl, Block, 
   Extend, Implement, QidList, Qid;
-synthesized attribute syn_imports::[(String, Decorated Usage_type)] occurs on DeclList, Decl, Block, 
+synthesized attribute syn_imports::[Decorated Usage_type] occurs on DeclList, Decl, Block, 
   Extend, Implement, QidList, Qid;
 
 -- Information required for synthesizing a graph node at the root of an AST
@@ -47,7 +47,7 @@ synthesized attribute syn_scopes::[Decorated Scope_type] occurs on DeclList, Dec
   Extend, Implement, QidList, Qid;
 
 -- The import synthesized in the "iqid" construct of the scope graph construction algorithm for this language example
-synthesized attribute syn_iqid_import::(String, Decorated Usage_type) occurs on Qid;
+synthesized attribute syn_iqid_import::Decorated Usage_type occurs on Qid;
 
 ------------------------------------------------------------
 ---- Program
@@ -133,7 +133,7 @@ top::Decl ::= id::ID_t extend::Extend implement::Implement block::Block
     id.column
   );
 
-  top.syn_decls = [(id.lexeme, init_decl)];
+  top.syn_decls = [init_decl];
   top.syn_refs = [];
   top.syn_imports = [];
   top.syn_all_scopes = [new_scope] ++ extend.syn_all_scopes ++ implement.syn_all_scopes ++ block.syn_all_scopes;
@@ -288,12 +288,12 @@ top::Qid ::= id::ID_t qid::Qid
     nothing(),
     qid.syn_decls,
     qid.syn_refs,
-    qid.syn_imports ++ [(id.lexeme, init_usage)],
+    qid.syn_imports ++ [init_usage],
     qid.syn_scopes -- ADD
   );
 
   top.syn_decls = [];
-  top.syn_refs = [(id.lexeme, init_usage)];
+  top.syn_refs = [init_usage];
   top.syn_imports = [];
   top.syn_all_scopes = [init_scope] ++ qid.syn_all_scopes;
   top.syn_iqid_import = qid.syn_iqid_import;
@@ -324,9 +324,9 @@ top::Qid ::= id::ID_t
   );
 
   top.syn_decls = [];
-  top.syn_refs = [(id.lexeme, init_import)];
+  top.syn_refs = [init_import];
   top.syn_imports = [];
-  top.syn_iqid_import = (id.lexeme, init_import_two);
+  top.syn_iqid_import = init_import_two;
   top.syn_all_scopes = [];
   top.syn_scopes = [];
 

--- a/grammars/minijava/AbstractSyntax.sv
+++ b/grammars/minijava/AbstractSyntax.sv
@@ -63,7 +63,8 @@ top::Program ::= list::DeclList
     list.syn_decls,
     list.syn_refs,
     list.syn_imports,
-    list.syn_scopes
+    list.syn_scopes,
+    nothing()
   );
 
   local attribute init_graph::Graph_type = cons_graph(init_scope::list.syn_all_scopes);
@@ -122,7 +123,8 @@ top::Decl ::= id::ID_t extend::Extend implement::Implement block::Block
     extend.syn_decls ++ implement.syn_decls ++ block.syn_decls,
     extend.syn_refs ++ implement.syn_refs ++ block.syn_refs,
     extend.syn_refs ++ implement.syn_refs ++ block.syn_refs,
-    extend.syn_scopes ++ implement.syn_scopes ++ block.syn_scopes
+    extend.syn_scopes ++ implement.syn_scopes ++ block.syn_scopes,
+    just(init_decl)
   );
 
   local attribute init_decl::Decl_type = cons_decl(
@@ -243,7 +245,7 @@ top::QidList ::= qid::Qid list::QidList
   top.syn_refs = qid.syn_refs ++ list.syn_refs;
   top.syn_imports = qid.syn_imports ++ [qid.syn_iqid_import] ++ list.syn_imports; -- rqid followed by iqid in construction rules
   top.syn_all_scopes = qid.syn_all_scopes ++ list.syn_all_scopes;
-  top.syn_scopes = qid.syn_scopes ++ list.syn_scopes; -- ADD
+  top.syn_scopes = qid.syn_scopes ++ list.syn_scopes; 
 
   qid.inh_scope = top.inh_scope;
   qid.inh_scope_two = top.inh_scope;
@@ -261,7 +263,7 @@ top::QidList ::= qid::Qid
   top.syn_refs = qid.syn_refs;
   top.syn_imports = qid.syn_imports ++ [qid.syn_iqid_import]; -- rqid followed by iqid in construction rules
   top.syn_all_scopes = qid.syn_all_scopes;
-  top.syn_scopes = qid.syn_scopes; -- ADD
+  top.syn_scopes = qid.syn_scopes; 
 
   qid.inh_scope = top.inh_scope;
   qid.inh_scope_two = top.inh_scope;
@@ -277,6 +279,15 @@ top::QidList ::= qid::Qid
 abstract production qid_dot
 top::Qid ::= id::ID_t qid::Qid
 {
+  local attribute init_scope::Scope_type = cons_scope (
+    nothing(),
+    qid.syn_decls,
+    qid.syn_refs,
+    qid.syn_imports ++ [init_usage],
+    qid.syn_scopes, 
+    nothing()
+  );
+
   local attribute init_usage::Usage_type = cons_usage ( -- rqid
     id.lexeme,
     top.inh_scope,
@@ -284,20 +295,12 @@ top::Qid ::= id::ID_t qid::Qid
     id.column
   );
 
-  local attribute init_scope::Scope_type = cons_scope (
-    nothing(),
-    qid.syn_decls,
-    qid.syn_refs,
-    qid.syn_imports ++ [init_usage],
-    qid.syn_scopes -- ADD
-  );
-
   top.syn_decls = [];
   top.syn_refs = [init_usage];
   top.syn_imports = [];
   top.syn_all_scopes = [init_scope] ++ qid.syn_all_scopes;
   top.syn_iqid_import = qid.syn_iqid_import;
-  top.syn_scopes = []; -- ADD
+  top.syn_scopes = []; 
   
   qid.inh_scope = init_scope;
   qid.inh_scope_two = top.inh_scope_two;

--- a/grammars/minijava/AbstractSyntax.sv
+++ b/grammars/minijava/AbstractSyntax.sv
@@ -1,5 +1,8 @@
 grammar minijava;
 
+imports scopegraph;
+
+
 nonterminal Program;
 nonterminal DeclList;
 nonterminal Decl;
@@ -9,8 +12,42 @@ nonterminal Implement;
 nonterminal QidList;
 nonterminal Qid;
 
+-- Types used in scope graphs for this language example
+type Graph_type = Graph;
+type Scope_type = Scope;
+type Decl_type = Declaration;
+type Usage_type = Usage;
+type Error_type = Error;
+type Path_type = Path;
+
 -- Printing AST term
 synthesized attribute pp::String occurs on Program, DeclList, Decl, Block, Extend, Implement, QidList, Qid;
+
+-- Information required for constructing scope nodes with references, declarations and imports
+-- Sub-expressions can synthesize each of these, which must be given to the enclosing scope
+synthesized attribute syn_decls::[(String, Decorated Decl_type)] occurs on DeclList, Decl, Block, 
+  Extend, Implement, QidList, Qid;
+synthesized attribute syn_refs::[(String, Decorated Usage_type)] occurs on DeclList, Decl, Block, 
+  Extend, Implement, QidList, Qid;
+synthesized attribute syn_imports::[(String, Decorated Usage_type)] occurs on DeclList, Decl, Block, 
+  Extend, Implement, QidList, Qid;
+
+-- Information required for synthesizing a graph node at the root of an AST
+synthesized attribute syn_graph::Decorated Graph_type occurs on Program;
+synthesized attribute syn_all_scopes::[Decorated Scope_type] occurs on DeclList, Decl, Block, 
+  Extend, Implement, QidList, Qid;
+
+-- The inherited scope passed to a node is the scope in which the corresponding construct resides
+inherited attribute inh_scope::Decorated Scope_type occurs on DeclList, Decl, Block, 
+  Extend, Implement, QidList, Qid;
+  inherited attribute inh_scope_two::Decorated Scope_type occurs on Qid;
+
+-- For double-edged arrow between parent and child scopes
+synthesized attribute syn_scopes::[Decorated Scope_type] occurs on DeclList, Decl, Block, 
+  Extend, Implement, QidList, Qid;
+
+-- The import synthesized in the "iqid" construct of the scope graph construction algorithm for this language example
+synthesized attribute syn_iqid_import::(String, Decorated Usage_type) occurs on Qid;
 
 ------------------------------------------------------------
 ---- Program
@@ -19,6 +56,22 @@ synthesized attribute pp::String occurs on Program, DeclList, Decl, Block, Exten
 abstract production prog
 top::Program ::= list::DeclList
 {
+
+  -- The root scope of the program
+  local attribute init_scope::Scope_type = cons_scope(
+    nothing(),
+    list.syn_decls,
+    list.syn_refs,
+    list.syn_imports,
+    list.syn_scopes
+  );
+
+  local attribute init_graph::Graph_type = cons_graph(init_scope::list.syn_all_scopes);
+  top.syn_graph = init_graph; -- simply substituting cons_graph(...) here does not work
+
+  list.inh_scope = init_scope;
+
+  -- ast printing
   top.pp = "prog(" ++ list.pp ++ ")";
 }
 
@@ -29,12 +82,30 @@ top::Program ::= list::DeclList
 abstract production decllist_list
 top::DeclList ::= decl::Decl list::DeclList
 {
+  top.syn_decls = decl.syn_decls ++ list.syn_decls;
+  top.syn_refs = decl.syn_refs ++ list.syn_refs;
+  top.syn_imports = decl.syn_imports ++ list.syn_imports;
+  top.syn_all_scopes = decl.syn_all_scopes ++ list.syn_all_scopes;
+  top.syn_scopes = decl.syn_scopes ++ list.syn_scopes;
+
+  decl.inh_scope = top.inh_scope;
+
+  list.inh_scope = top.inh_scope;
+
+  -- ast printing
   top.pp = "decllist_list(" ++ decl.pp ++ ", " ++ list.pp ++ ")";
 }
 
 abstract production decllist_nothing
 top::DeclList ::=
 {
+  top.syn_decls = [];
+  top.syn_refs = [];
+  top.syn_imports = [];
+  top.syn_all_scopes = [];
+  top.syn_scopes = [];
+
+  -- ast printing
   top.pp = "decllist_nothing()";
 }
 
@@ -45,6 +116,36 @@ top::DeclList ::=
 abstract production decl_class
 top::Decl ::= id::ID_t extend::Extend implement::Implement block::Block
 {
+  -- New scope for a class
+  local attribute new_scope::Scope_type = cons_scope(
+    just(top.inh_scope),
+    extend.syn_decls ++ implement.syn_decls ++ block.syn_decls,
+    extend.syn_refs ++ implement.syn_refs ++ block.syn_refs,
+    extend.syn_refs ++ implement.syn_refs ++ block.syn_refs,
+    extend.syn_scopes ++ implement.syn_scopes ++ block.syn_scopes
+  );
+
+  local attribute init_decl::Decl_type = cons_decl(
+    id.lexeme,
+    top.inh_scope,
+    just(new_scope),
+    id.line,
+    id.column
+  );
+
+  top.syn_decls = [(id.lexeme, init_decl)];
+  top.syn_refs = [];
+  top.syn_imports = [];
+  top.syn_all_scopes = [new_scope] ++ extend.syn_all_scopes ++ implement.syn_all_scopes ++ block.syn_all_scopes;
+  top.syn_scopes = [new_scope];
+
+  extend.inh_scope = new_scope;
+
+  implement.inh_scope = new_scope;
+
+  block.inh_scope = new_scope;
+
+  -- ast printing
   top.pp = "decl_class(" ++ id.lexeme ++ ", " ++ extend.pp ++ ", " ++ implement.pp ++ ", " ++ block.pp ++ ")";
 }
 
@@ -55,6 +156,15 @@ top::Decl ::= id::ID_t extend::Extend implement::Implement block::Block
 abstract production block
 top::Block ::= list::DeclList
 {
+  top.syn_decls = list.syn_decls;
+  top.syn_refs = list.syn_refs;
+  top.syn_imports = list.syn_imports;
+  top.syn_all_scopes = list.syn_all_scopes;
+  top.syn_scopes = list.syn_scopes;
+
+  list.inh_scope = top.inh_scope;
+
+  -- ast printing
   top.pp = "block(" ++ list.pp ++ ")";
 }
 
@@ -65,12 +175,28 @@ top::Block ::= list::DeclList
 abstract production extendlist_list
 top::Extend ::= list::QidList
 {
+  top.syn_decls = list.syn_decls;
+  top.syn_refs = list.syn_refs;
+  top.syn_imports = list.syn_imports;
+  top.syn_all_scopes = list.syn_all_scopes;
+  top.syn_scopes = list.syn_scopes;
+
+  list.inh_scope = top.inh_scope;
+
+  -- ast printing
   top.pp = "extendlist_list(" ++ list.pp ++ ")";
 }
 
 abstract production extendlist_nothing
 top::Extend ::=
 {
+  top.syn_decls = [];
+  top.syn_refs = [];
+  top.syn_imports = [];
+  top.syn_all_scopes = [];
+  top.syn_scopes = [];
+
+  -- ast printing
   top.pp = "extendlist_nothing()";
 }
 
@@ -81,12 +207,28 @@ top::Extend ::=
 abstract production implementlist_list
 top::Implement ::= list::QidList
 {
+  top.syn_decls = list.syn_decls;
+  top.syn_refs = list.syn_refs;
+  top.syn_imports = list.syn_imports;
+  top.syn_all_scopes = list.syn_all_scopes;
+  top.syn_scopes = list.syn_scopes;
+
+  list.inh_scope = top.inh_scope;
+
+  -- ast printing
   top.pp = "implementlist_list(" ++ list.pp ++ ")";
 }
 
 abstract production implementlist_nothing
 top::Implement ::=
 {
+  top.syn_decls = [];
+  top.syn_refs = [];
+  top.syn_imports = [];
+  top.syn_all_scopes = [];
+  top.syn_scopes = [];
+
+  -- ast printing
   top.pp = "implementlist_nothing()";
 }
 
@@ -97,12 +239,34 @@ top::Implement ::=
 abstract production qidlist_list
 top::QidList ::= qid::Qid list::QidList
 {
+  top.syn_decls = qid.syn_decls ++ list.syn_decls;
+  top.syn_refs = qid.syn_refs ++ list.syn_refs;
+  top.syn_imports = qid.syn_imports ++ [qid.syn_iqid_import] ++ list.syn_imports; -- rqid followed by iqid in construction rules
+  top.syn_all_scopes = qid.syn_all_scopes ++ list.syn_all_scopes;
+  top.syn_scopes = qid.syn_scopes ++ list.syn_scopes; -- ADD
+
+  qid.inh_scope = top.inh_scope;
+  qid.inh_scope_two = top.inh_scope;
+
+  list.inh_scope = top.inh_scope;
+
+  -- ast printing
   top.pp = "qidlist_list(" ++ qid.pp ++ ", " ++ list.pp ++ ")";
 }
 
 abstract production qidlist_single
 top::QidList ::= qid::Qid
 {
+  top.syn_decls = qid.syn_decls;
+  top.syn_refs = qid.syn_refs;
+  top.syn_imports = qid.syn_imports ++ [qid.syn_iqid_import]; -- rqid followed by iqid in construction rules
+  top.syn_all_scopes = qid.syn_all_scopes;
+  top.syn_scopes = qid.syn_scopes; -- ADD
+
+  qid.inh_scope = top.inh_scope;
+  qid.inh_scope_two = top.inh_scope;
+
+  -- ast printing
   top.pp = "qidlist_single(" ++ qid.pp ++ ")";
 }
 
@@ -113,11 +277,62 @@ top::QidList ::= qid::Qid
 abstract production qid_dot
 top::Qid ::= id::ID_t qid::Qid
 {
+  local attribute init_usage::Usage_type = cons_usage ( -- rqid
+    id.lexeme,
+    top.inh_scope,
+    id.line,
+    id.column
+  );
+
+  local attribute init_scope::Scope_type = cons_scope (
+    nothing(),
+    qid.syn_decls,
+    qid.syn_refs,
+    qid.syn_imports ++ [(id.lexeme, init_usage)],
+    qid.syn_scopes -- ADD
+  );
+
+  top.syn_decls = [];
+  top.syn_refs = [(id.lexeme, init_usage)];
+  top.syn_imports = [];
+  top.syn_all_scopes = [init_scope] ++ qid.syn_all_scopes;
+  top.syn_iqid_import = qid.syn_iqid_import;
+  top.syn_scopes = []; -- ADD
+  
+  qid.inh_scope = init_scope;
+  qid.inh_scope_two = top.inh_scope_two;
+  
+  -- ast printing
   top.pp = "qid_dot(" ++ id.lexeme ++ ", " ++ qid.pp ++ ")";
 }
 
 abstract production qid_single
 top::Qid ::= id::ID_t
 {
+  local attribute init_import_two::Usage_type = cons_usage (
+    id.lexeme,
+    top.inh_scope_two,
+    id.line,
+    id.column
+  );
+
+  local attribute init_import::Usage_type = cons_usage (
+    id.lexeme,
+    top.inh_scope,
+    id.line,
+    id.column
+  );
+
+  top.syn_decls = [];
+  top.syn_refs = [(id.lexeme, init_import)];
+  top.syn_imports = [];
+  top.syn_iqid_import = (id.lexeme, init_import_two);
+  top.syn_all_scopes = [];
+  top.syn_scopes = [];
+
+  --local attribute fst_path::Path_type = cons_path(init_import, head(init_import.resolutions)); -- TODO: in case of errors print some paths anyway
+  --top.paths = [fst_path];
+
+  -- ast printing
   top.pp = "qid_single(" ++ id.lexeme ++ ")";
 }

--- a/grammars/minijava/AbstractSyntax.sv
+++ b/grammars/minijava/AbstractSyntax.sv
@@ -6,7 +6,11 @@ nonterminal Decl;
 nonterminal Block;
 nonterminal Extend;
 nonterminal Implement;
+nonterminal QidList;
 nonterminal Qid;
+
+-- Printing AST term
+synthesized attribute pp::String occurs on Program, DeclList, Decl, Block, Extend, Implement, QidList, Qid;
 
 ------------------------------------------------------------
 ---- Program
@@ -15,7 +19,7 @@ nonterminal Qid;
 abstract production prog
 top::Program ::= list::DeclList
 {
-
+  top.pp = "prog(" ++ list.pp ++ ")";
 }
 
 ------------------------------------------------------------
@@ -25,13 +29,13 @@ top::Program ::= list::DeclList
 abstract production decllist_list
 top::DeclList ::= decl::Decl list::DeclList
 {
-
+  top.pp = "decllist_list(" ++ decl.pp ++ ", " ++ list.pp ++ ")";
 }
 
 abstract production decllist_nothing
 top::DeclList ::=
 {
-
+  top.pp = "decllist_nothing()";
 }
 
 ------------------------------------------------------------
@@ -41,7 +45,7 @@ top::DeclList ::=
 abstract production decl_class
 top::Decl ::= id::ID_t extend::Extend implement::Implement block::Block
 {
-
+  top.pp = "decl_class(" ++ id.lexeme ++ ", " ++ extend.pp ++ ", " ++ implement.pp ++ ", " ++ block.pp ++ ")";
 }
 
 ------------------------------------------------------------
@@ -49,9 +53,9 @@ top::Decl ::= id::ID_t extend::Extend implement::Implement block::Block
 ------------------------------------------------------------
 
 abstract production block
-top::Block ::=
+top::Block ::= list::DeclList
 {
-
+  top.pp = "block(" ++ list.pp ++ ")";
 }
 
 ------------------------------------------------------------
@@ -59,15 +63,15 @@ top::Block ::=
 ------------------------------------------------------------
 
 abstract production extendlist_list
-top::Extend ::= qid::Qid
+top::Extend ::= list::QidList
 {
-
+  top.pp = "extendlist_list(" ++ list.pp ++ ")";
 }
 
 abstract production extendlist_nothing
 top::Extend ::=
 {
-
+  top.pp = "extendlist_nothing()";
 }
 
 ------------------------------------------------------------
@@ -75,29 +79,45 @@ top::Extend ::=
 ------------------------------------------------------------
 
 abstract production implementlist_list
-top::Implement ::= qid::Qid
+top::Implement ::= list::QidList
 {
-
+  top.pp = "implementlist_list(" ++ list.pp ++ ")";
 }
 
 abstract production implementlist_nothing
 top::Implement ::=
 {
-
+  top.pp = "implementlist_nothing()";
 }
 
 ------------------------------------------------------------
----- Implement
+---- Qid list
 ------------------------------------------------------------
 
-abstract production qid_list
+abstract production qidlist_list
+top::QidList ::= qid::Qid list::QidList
+{
+  top.pp = "qidlist_list(" ++ qid.pp ++ ", " ++ list.pp ++ ")";
+}
+
+abstract production qidlist_single
+top::QidList ::= qid::Qid
+{
+  top.pp = "qidlist_single(" ++ qid.pp ++ ")";
+}
+
+------------------------------------------------------------
+---- Qid
+------------------------------------------------------------
+
+abstract production qid_dot
 top::Qid ::= id::ID_t qid::Qid
 {
-
+  top.pp = "qid_dot(" ++ id.lexeme ++ ", " ++ qid.pp ++ ")";
 }
 
 abstract production qid_single
 top::Qid ::= id::ID_t
 {
-
+  top.pp = "qid_single(" ++ id.lexeme ++ ")";
 }

--- a/grammars/minijava/ConcreteSyntax.sv
+++ b/grammars/minijava/ConcreteSyntax.sv
@@ -1,0 +1,105 @@
+grammar minijava;
+
+synthesized attribute ast<a>::a;
+
+nonterminal Program_c with ast<Program>;
+nonterminal DeclList_c with ast<DeclList>;
+nonterminal Decl_c with ast<Decl>;
+nonterminal Block_c with ast<Block>;
+nonterminal Extend_c with ast<Extend>;
+nonterminal Implement_c with ast<Implement>;
+nonterminal Qid_c with ast<Qid>;
+
+------------------------------------------------------------
+---- Program
+------------------------------------------------------------
+
+concrete production program_c
+top::Program_c ::= list::DeclList_c
+{
+  top.ast = prog(list.ast);
+}
+
+------------------------------------------------------------
+---- Declaration Lists
+------------------------------------------------------------
+
+concrete production decllist_list_c
+top::DeclList_c ::= decl::Decl_c list::DeclList_c
+{
+  top.ast = decllist_list(decl.ast, list.ast);
+}
+
+concrete production decllist_nothing_c
+top::DeclList_c ::=
+{
+  top.ast = decllist_nothing();
+}
+
+------------------------------------------------------------
+---- Declarations
+------------------------------------------------------------
+
+concrete production decl_class_c
+top::Decl_c ::= Class_t id::ID_t extend::Extend_c implement::Implement_c block::Block_c
+{
+  top.ast = decl_class(id, extend.ast, implement.ast, block.ast);
+}
+
+------------------------------------------------------------
+---- Block
+------------------------------------------------------------
+
+concrete production block_c
+top::Block_c ::= LCurly_t RCurly_t
+{
+  top.ast = block();
+}
+
+------------------------------------------------------------
+---- Extend
+------------------------------------------------------------
+
+concrete production extendlist_list_c
+top::Extend_c ::= Extends_t qid::Qid_c
+{
+  top.ast = extendlist_list(qid.ast);
+}
+
+concrete production extendlist_nothing_c
+top::Extend_c ::=
+{
+  top.ast = extendlist_nothing();
+}
+
+------------------------------------------------------------
+---- Implement
+------------------------------------------------------------
+
+concrete production implementlist_list_c
+top::Implement_c ::= Implements_t qid::Qid_c
+{
+  top.ast = implementlist_list(qid.ast);
+}
+
+concrete productionimplementlist_nothing_c
+top::Implement_c ::=
+{
+  top.ast = implementlist_nothing();
+}
+
+------------------------------------------------------------
+---- Implement
+------------------------------------------------------------
+
+concrete production qid_list_c
+top::Qid_c ::= id::ID_t Dot_t qid::Qid_c
+{
+  top.ast = qid_list(id, qid.ast);
+}
+
+concrete production qid_single_c
+top::Qid_c ::= id::ID_t
+{
+  top.ast = qid_single(id);
+}

--- a/grammars/minijava/ConcreteSyntax.sv
+++ b/grammars/minijava/ConcreteSyntax.sv
@@ -8,6 +8,7 @@ nonterminal Decl_c with ast<Decl>;
 nonterminal Block_c with ast<Block>;
 nonterminal Extend_c with ast<Extend>;
 nonterminal Implement_c with ast<Implement>;
+nonterminal QidList_c with ast<QidList>;
 nonterminal Qid_c with ast<Qid>;
 
 ------------------------------------------------------------
@@ -51,9 +52,9 @@ top::Decl_c ::= Class_t id::ID_t extend::Extend_c implement::Implement_c block::
 ------------------------------------------------------------
 
 concrete production block_c
-top::Block_c ::= LCurly_t RCurly_t
+top::Block_c ::= LCurly_t list::DeclList_c RCurly_t
 {
-  top.ast = block();
+  top.ast = block(list.ast);
 }
 
 ------------------------------------------------------------
@@ -61,9 +62,9 @@ top::Block_c ::= LCurly_t RCurly_t
 ------------------------------------------------------------
 
 concrete production extendlist_list_c
-top::Extend_c ::= Extends_t qid::Qid_c
+top::Extend_c ::= Extends_t list::QidList_c
 {
-  top.ast = extendlist_list(qid.ast);
+  top.ast = extendlist_list(list.ast);
 }
 
 concrete production extendlist_nothing_c
@@ -77,9 +78,9 @@ top::Extend_c ::=
 ------------------------------------------------------------
 
 concrete production implementlist_list_c
-top::Implement_c ::= Implements_t qid::Qid_c
+top::Implement_c ::= Implements_t list::QidList_c
 {
-  top.ast = implementlist_list(qid.ast);
+  top.ast = implementlist_list(list.ast);
 }
 
 concrete productionimplementlist_nothing_c
@@ -89,13 +90,29 @@ top::Implement_c ::=
 }
 
 ------------------------------------------------------------
----- Implement
+---- Qid list
 ------------------------------------------------------------
 
-concrete production qid_list_c
+concrete production qidlist_list_c
+top::QidList_c ::= qid::Qid_c Comma_t list::QidList_c
+{
+  top.ast = qidlist_list(qid.ast, list.ast);
+}
+
+concrete production qidlist_single_c
+top::QidList_c ::= qid::Qid_c
+{
+  top.ast = qidlist_single(qid.ast);
+}
+
+------------------------------------------------------------
+---- Qid
+------------------------------------------------------------
+
+concrete production qid_dot_c
 top::Qid_c ::= id::ID_t Dot_t qid::Qid_c
 {
-  top.ast = qid_list(id, qid.ast);
+  top.ast = qid_dot(id, qid.ast);
 }
 
 concrete production qid_single_c

--- a/grammars/minijava/Main.sv
+++ b/grammars/minijava/Main.sv
@@ -1,5 +1,8 @@
 grammar minijava;
 
+global file_output::String = "scope_graph_minijava.svg";
+
+
 parser parse :: Program_c {
     minijava;
 }
@@ -18,11 +21,44 @@ IOVal<Integer> ::= largs::[String] ioin::IOToken
 
   local attribute r::Program = r_cst.ast;
 
-  local attribute print_success :: IOToken;
-  print_success = printT("Success!\n" ++ r.pp ++ "\n", ioin);
+  local attribute scope_graph :: Graph_type;
+  scope_graph = new(r.syn_graph);
+
+  --local attribute print_success :: IOToken;
+  --print_success = ;
 
   local attribute print_failure :: IOToken;
-  print_failure = printT("Something went wrong!\n", ioin);
+  print_failure = printT(string_errors(scope_graph.errors), ioin);
 
-  return ioval(if result.parseSuccess then print_success else print_failure, 0);
+  local attribute print_resolution_paths :: IOToken;
+  print_resolution_paths = systemT("echo '" ++ 
+    graphviz_draw_graph(scope_graph, (contains("--show-resolutions", largs)), (contains("--show-children", largs))) ++ 
+    "' | dot -Tsvg > " ++ file_output, printT(if (contains("--graph-print", largs)) then "Graph print:\n" ++ graphviz_draw_graph(scope_graph, true, true) ++ "\n" else "", ioin)).io;
+
+{-
+  local res::IO<Integer> = do {
+    if length(largs) < 1 then do {
+      print ("Usage: java -jar ***.jar <file name> <options>\n");
+      return 1;
+    }
+    else do {
+
+
+    if length(r.errors) > 0
+    then 
+      do { 
+        print ("Errors:\n" ++ string_errors(r.errors));
+        return 1;
+      }
+    else
+      do {
+       print ("Hello!\n");
+       return 1;
+      } ;
+    } ;
+-}
+  --return 
+      --ioval(if length(r.errors) <= 0 then print_resolution_paths else print_failure, 0);
+      return if length(scope_graph.errors) <= 0 then ioval(print_resolution_paths, 0) else ioval(print_resolution_paths, -1);
+     -- evalIO (res, ioin) ;
 }

--- a/grammars/minijava/Main.sv
+++ b/grammars/minijava/Main.sv
@@ -1,0 +1,28 @@
+grammar minijava;
+
+parser parse :: Program_c {
+    minijava;
+}
+
+function main
+IOVal<Integer> ::= largs::[String] ioin::IOToken
+{
+  local attribute args::String;
+  args = head(largs);
+
+  local attribute result :: ParseResult<Program_c>;
+  result = parse(args, "<<args>>");
+
+  local attribute r_cst::Program_c;
+  r_cst = result.parseTree;
+
+  local attribute r::Program = r_cst.ast;
+
+  local attribute print_success :: IOToken;
+  print_success = printT("Success!\n" ++ r.pp ++ "\n", ioin);
+
+  local attribute print_failure :: IOToken;
+  print_failure = printT("Something went wrong!\n", ioin);
+
+  return ioval(if result.parseSuccess then print_success else print_failure, 0);
+}

--- a/grammars/minijava/Terminals.sv
+++ b/grammars/minijava/Terminals.sv
@@ -1,6 +1,6 @@
 grammar minijava;
 
-terminal ID_t /[a-zA-Z_]*/;
+terminal ID_t /[a-zA-Z_][a-zA-Z0-9_]*/;
 terminal Int_t /(0|-?[1-9][0-9]*)/;
 
 terminal Class_t 'class' dominates {ID_t};
@@ -9,6 +9,7 @@ terminal Extends_t 'extends' dominates {ID_t};
 terminal Implements_t 'implements' dominates {ID_t};
 
 terminal Dot_t '.';
+terminal Comma_t ',';
 
 terminal LCurly_t '{';
 terminal RCurly_t '}';

--- a/grammars/minijava/Terminals.sv
+++ b/grammars/minijava/Terminals.sv
@@ -1,0 +1,16 @@
+grammar minijava;
+
+terminal ID_t /[a-zA-Z_]*/;
+terminal Int_t /(0|-?[1-9][0-9]*)/;
+
+terminal Class_t 'class' dominates {ID_t};
+terminal Interface_t 'interface' dominates {ID_t};
+terminal Extends_t 'extends' dominates {ID_t};
+terminal Implements_t 'implements' dominates {ID_t};
+
+terminal Dot_t '.';
+
+terminal LCurly_t '{';
+terminal RCurly_t '}';
+
+ignore terminal Whitespace_t /[\n\r\t ]+/;

--- a/grammars/scopegraph/Draw.sv
+++ b/grammars/scopegraph/Draw.sv
@@ -35,8 +35,8 @@ String ::= scopes::[Decorated Scope<a>]
   return case scopes of 
     | [] -> ""
     | h::t -> 
-      h.to_string ++ (case h.parent of | nothing() 
-        -> "" | just(p) -> " -> " ++ p.to_string end) ++ " " ++ 
+      h.graphviz_name ++ (case h.parent of | nothing() 
+        -> "" | just(p) -> " -> " ++ p.graphviz_name end) ++ " " ++ 
       graphviz_scope_refs(h, h.references) ++ 
       graphviz_scope_decls(h, h.declarations) ++ 
       "{edge [arrowhead=onormal] " ++ graphviz_scope_imports(h, h.imports) ++ "}" ++
@@ -55,7 +55,7 @@ String ::= scope::Decorated Scope<a> refs::[(String, Decorated Usage<a>)]
 {
   return case refs of 
     | [] -> ""
-    | (h1, h2)::t -> h2.to_string ++ " -> " ++ scope.to_string ++ " " ++ 
+    | (h1, h2)::t -> h2.graphviz_name ++ " -> " ++ scope.graphviz_name ++ " " ++ 
       graphviz_scope_refs(scope, t)
   end;
 }
@@ -71,7 +71,7 @@ String ::= scope::Decorated Scope<a> refs::[(String, Decorated Usage<a>)]
 {
   return case refs of 
     | [] -> ""
-    | (h1, h2)::t -> scope.to_string ++ " -> " ++ h2.to_string ++ " " ++ 
+    | (h1, h2)::t -> scope.graphviz_name ++ " -> " ++ h2.graphviz_name ++ " " ++ 
       graphviz_scope_imports(scope, t)
   end;
 }
@@ -88,10 +88,10 @@ String ::= scope::Decorated Scope<a> decls::[(String, Decorated Declaration<a>)]
   return case decls of 
     | [] -> ""
     | (h1, h2)::t -> 
-      scope.to_string ++ " -> " ++ h2.to_string ++ " " ++ 
+      scope.graphviz_name ++ " -> " ++ h2.graphviz_name ++ " " ++ 
       (case h2.assoc_scope of 
         | nothing() -> "" 
-        | just(s) -> "{ edge [arrowhead=onormal]" ++ h2.to_string ++ " -> " ++ s.to_string ++ "} " 
+        | just(s) -> "{ edge [arrowhead=onormal]" ++ h2.graphviz_name ++ " -> " ++ s.graphviz_name ++ "} " 
       end) ++ 
       graphviz_scope_decls(scope, t)
   end;
@@ -109,7 +109,7 @@ String ::= scopes::[Decorated Scope<a>]
   return "{edge [color=pink style=dashed] " ++
     foldl((\accone::String h::Decorated Scope<a> ->
     accone ++ (foldl(
-      (\acc::String child::Decorated Scope<a> -> acc ++ " " ++ h.to_string ++ " -> "  ++ child.to_string),
+      (\acc::String child::Decorated Scope<a> -> acc ++ " " ++ h.graphviz_name ++ " -> "  ++ child.graphviz_name),
       "",
       h.child_scopes
     ))), "", scopes) ++ "}";
@@ -125,7 +125,7 @@ function graphviz_draw_paths
 String ::= paths::[Decorated Path<a>]
 {
   return "{edge [color=blue style=dashed] " ++ foldl((\acc::String path::Decorated Path<a> -> 
-    acc ++ " " ++ path.start.to_string ++ " -> " ++ path.final.to_string), "", paths) ++ "}";
+    acc ++ " " ++ path.start.graphviz_name ++ " -> " ++ path.final.graphviz_name), "", paths) ++ "}";
 }
 -}
 
@@ -137,8 +137,8 @@ String ::= graph::Decorated Graph<a>
       let 
         both::Pair<[Decorated Usage<a>] [Decorated Usage<a>]> = partition((\usg::Decorated Usage<a> -> length(usg.resolutions) == 1), map((\usg::(String, Decorated Usage<a>) -> snd(usg)), cur_scope.references ++ cur_scope.imports))
       in 
-        "{edge [arrowhead=normal color=blue style=dashed]" ++ foldl((\acc::String usg::Decorated Usage<a> -> acc ++ " " ++ usg.to_string ++ " -> " ++ head(usg.resolutions).to_string), "", fst(both)) ++ " }" ++ 
-        "{node [color=red shape=box fontsize=12] edge [arrowhead=normal color=red style=dashed]" ++ foldl((\acc::String usg::Decorated Usage<a> -> acc ++ " " ++ usg.to_string ++ " " ++ foldl((\acc::String decl::Decorated Declaration<a> -> acc ++ " " ++ usg.to_string ++ " -> " ++ decl.to_string), "", usg.resolutions)), "", snd(both)) ++ " }"
+        "{edge [arrowhead=normal color=blue style=dashed]" ++ foldl((\acc::String usg::Decorated Usage<a> -> acc ++ " " ++ usg.graphviz_name ++ " -> " ++ head(usg.resolutions).graphviz_name), "", fst(both)) ++ " }" ++ 
+        "{node [color=red shape=box fontsize=12] edge [arrowhead=normal color=red style=dashed]" ++ foldl((\acc::String usg::Decorated Usage<a> -> acc ++ " " ++ usg.graphviz_name ++ " " ++ foldl((\acc::String decl::Decorated Declaration<a> -> acc ++ " " ++ usg.graphviz_name ++ " -> " ++ decl.graphviz_name), "", usg.resolutions)), "", snd(both)) ++ " }"
       end ++ "\n"
     ),
     "",

--- a/grammars/scopegraph/Draw.sv
+++ b/grammars/scopegraph/Draw.sv
@@ -51,12 +51,11 @@ String ::= scopes::[Decorated Scope]
  - @return The graphviz string representing the list of references.
 -}
 function graphviz_scope_refs
-String ::= scope::Decorated Scope refs::[(String, Decorated Usage)]
+String ::= scope::Decorated Scope refs::[Decorated Usage]
 {
   return case refs of 
     | [] -> ""
-    | (h1, h2)::t -> h2.graphviz_name ++ " -> " ++ scope.graphviz_name ++ " " ++ 
-      graphviz_scope_refs(scope, t)
+    | h::t -> h.graphviz_name ++ " -> " ++ scope.graphviz_name ++ " " ++ graphviz_scope_refs(scope, t)
   end;
 }
 
@@ -67,12 +66,11 @@ String ::= scope::Decorated Scope refs::[(String, Decorated Usage)]
  - @return The graphviz string representing the list of imports.
 -}
 function graphviz_scope_imports
-String ::= scope::Decorated Scope refs::[(String, Decorated Usage)]
+String ::= scope::Decorated Scope refs::[Decorated Usage]
 {
   return case refs of 
     | [] -> ""
-    | (h1, h2)::t -> scope.graphviz_name ++ " -> " ++ h2.graphviz_name ++ " " ++ 
-      graphviz_scope_imports(scope, t)
+    | h::t -> scope.graphviz_name ++ " -> " ++ h.graphviz_name ++ " " ++ graphviz_scope_imports(scope, t)
   end;
 }
 
@@ -83,15 +81,15 @@ String ::= scope::Decorated Scope refs::[(String, Decorated Usage)]
  - @return The graphviz string representing the list of declarations.
 -}
 function graphviz_scope_decls
-String ::= scope::Decorated Scope decls::[(String, Decorated Declaration)]
+String ::= scope::Decorated Scope decls::[Decorated Declaration]
 {
   return case decls of 
     | [] -> ""
-    | (h1, h2)::t -> 
-      scope.graphviz_name ++ " -> " ++ h2.graphviz_name ++ " " ++ 
-      (case h2.assoc_scope of 
+    | h::t -> 
+      scope.graphviz_name ++ " -> " ++ h.graphviz_name ++ " " ++ 
+      (case h.assoc_scope of 
         | nothing() -> "" 
-        | just(s) -> "{ edge [arrowhead=onormal]" ++ h2.graphviz_name ++ " -> " ++ s.graphviz_name ++ "} " 
+        | just(s) -> "{ edge [arrowhead=onormal]" ++ h.graphviz_name ++ " -> " ++ s.graphviz_name ++ "} " 
       end) ++ 
       graphviz_scope_decls(scope, t)
   end;
@@ -129,8 +127,7 @@ String ::= graph::Decorated Graph
       (\acc::([Decorated Usage], [Decorated Usage]) cur_scope::Decorated Scope -> 
         let new_pair::([Decorated Usage], [Decorated Usage]) = 
           partition((\usg::Decorated Usage -> length(usg.resolutions) == 1), 
-            map((\usg::(String, Decorated Usage) -> snd(usg)), 
-              cur_scope.references ++ cur_scope.imports)) 
+            cur_scope.references ++ cur_scope.imports) 
         in 
           (fst(acc) ++ fst(new_pair), snd(acc) ++ snd(new_pair))
         end),

--- a/grammars/scopegraph/Draw.sv
+++ b/grammars/scopegraph/Draw.sv
@@ -138,9 +138,9 @@ String ::= graph::Decorated Graph
       graph.scope_list)
   in
     "{edge [arrowhead=normal color=blue style=dashed]" ++ 
-      draw_individual_paths(fst(all)) ++ "}" ++
+      graphviz_draw_individual_paths(fst(all)) ++ "}" ++
     "{node [color=red shape=box fontsize=12] edge [arrowhead=normal color=red style=dashed]" ++
-      draw_individual_paths(snd(all)) ++ "}"
+      graphviz_draw_individual_paths(snd(all)) ++ "}"
   end ++ "\n";
 }
 

--- a/grammars/scopegraph/Draw.sv
+++ b/grammars/scopegraph/Draw.sv
@@ -12,10 +12,10 @@ grammar scopegraph;
  - @return The string with which graphviz will draw a graph.
 -}
 function graphviz_draw_graph
-String ::= graph::Decorated Graph<a> draw_paths::Boolean draw_parents::Boolean
+String ::= graph::Decorated Graph draw_paths::Boolean draw_parents::Boolean
 {
   return "digraph {{ node [shape=circle style=solid fontsize=12] " ++ 
-    foldl((\acc::String scope::Decorated Scope<a> 
+    foldl((\acc::String scope::Decorated Scope 
       -> acc ++ " " ++ toString(scope.id)), "", graph.scope_list) ++ 
     "} node [shape=box fontsize=12] edge [arrowhead=normal] " ++ 
     (if draw_paths then graphviz_draw_paths(graph) else "") ++
@@ -30,7 +30,7 @@ String ::= graph::Decorated Graph<a> draw_paths::Boolean draw_parents::Boolean
  - @return The graphviz string representing the list of scopes.
 -}
 function graphviz_scopes
-String ::= scopes::[Decorated Scope<a>]
+String ::= scopes::[Decorated Scope]
 {
   return case scopes of 
     | [] -> ""
@@ -51,7 +51,7 @@ String ::= scopes::[Decorated Scope<a>]
  - @return The graphviz string representing the list of references.
 -}
 function graphviz_scope_refs
-String ::= scope::Decorated Scope<a> refs::[(String, Decorated Usage<a>)]
+String ::= scope::Decorated Scope refs::[(String, Decorated Usage)]
 {
   return case refs of 
     | [] -> ""
@@ -67,7 +67,7 @@ String ::= scope::Decorated Scope<a> refs::[(String, Decorated Usage<a>)]
  - @return The graphviz string representing the list of imports.
 -}
 function graphviz_scope_imports
-String ::= scope::Decorated Scope<a> refs::[(String, Decorated Usage<a>)]
+String ::= scope::Decorated Scope refs::[(String, Decorated Usage)]
 {
   return case refs of 
     | [] -> ""
@@ -83,7 +83,7 @@ String ::= scope::Decorated Scope<a> refs::[(String, Decorated Usage<a>)]
  - @return The graphviz string representing the list of declarations.
 -}
 function graphviz_scope_decls
-String ::= scope::Decorated Scope<a> decls::[(String, Decorated Declaration<a>)]
+String ::= scope::Decorated Scope decls::[(String, Decorated Declaration)]
 {
   return case decls of 
     | [] -> ""
@@ -104,12 +104,12 @@ String ::= scope::Decorated Scope<a> decls::[(String, Decorated Declaration<a>)]
  - @return The graphviz string representing the list of child edges.
 -}
 function graphviz_scope_children
-String ::= scopes::[Decorated Scope<a>]
+String ::= scopes::[Decorated Scope]
 {
   return "{edge [color=pink style=dashed] " ++
-    foldl((\accone::String h::Decorated Scope<a> ->
+    foldl((\accone::String h::Decorated Scope ->
     accone ++ (foldl(
-      (\acc::String child::Decorated Scope<a> -> acc ++ " " ++ h.graphviz_name ++ " -> "  ++ child.graphviz_name),
+      (\acc::String child::Decorated Scope -> acc ++ " " ++ h.graphviz_name ++ " -> "  ++ child.graphviz_name),
       "",
       h.child_scopes
     ))), "", scopes) ++ "}";
@@ -122,23 +122,23 @@ String ::= scopes::[Decorated Scope<a>]
  - @return The string with which graphviz will draw resolution paths.
 
 function graphviz_draw_paths
-String ::= paths::[Decorated Path<a>]
+String ::= paths::[Decorated Path]
 {
-  return "{edge [color=blue style=dashed] " ++ foldl((\acc::String path::Decorated Path<a> -> 
+  return "{edge [color=blue style=dashed] " ++ foldl((\acc::String path::Decorated Path -> 
     acc ++ " " ++ path.start.graphviz_name ++ " -> " ++ path.final.graphviz_name), "", paths) ++ "}";
 }
 -}
 
 function graphviz_draw_paths
-String ::= graph::Decorated Graph<a>
+String ::= graph::Decorated Graph
 {
   return foldl(
-    (\acc::String cur_scope::Decorated Scope<a> -> acc ++ 
+    (\acc::String cur_scope::Decorated Scope -> acc ++ 
       let 
-        both::Pair<[Decorated Usage<a>] [Decorated Usage<a>]> = partition((\usg::Decorated Usage<a> -> length(usg.resolutions) == 1), map((\usg::(String, Decorated Usage<a>) -> snd(usg)), cur_scope.references ++ cur_scope.imports))
+        both::Pair<[Decorated Usage] [Decorated Usage]> = partition((\usg::Decorated Usage -> length(usg.resolutions) == 1), map((\usg::(String, Decorated Usage) -> snd(usg)), cur_scope.references ++ cur_scope.imports))
       in 
-        "{edge [arrowhead=normal color=blue style=dashed]" ++ foldl((\acc::String usg::Decorated Usage<a> -> acc ++ " " ++ usg.graphviz_name ++ " -> " ++ head(usg.resolutions).graphviz_name), "", fst(both)) ++ " }" ++ 
-        "{node [color=red shape=box fontsize=12] edge [arrowhead=normal color=red style=dashed]" ++ foldl((\acc::String usg::Decorated Usage<a> -> acc ++ " " ++ usg.graphviz_name ++ " " ++ foldl((\acc::String decl::Decorated Declaration<a> -> acc ++ " " ++ usg.graphviz_name ++ " -> " ++ decl.graphviz_name), "", usg.resolutions)), "", snd(both)) ++ " }"
+        "{edge [arrowhead=normal color=blue style=dashed]" ++ foldl((\acc::String usg::Decorated Usage -> acc ++ " " ++ usg.graphviz_name ++ " -> " ++ head(usg.resolutions).graphviz_name), "", fst(both)) ++ " }" ++ 
+        "{node [color=red shape=box fontsize=12] edge [arrowhead=normal color=red style=dashed]" ++ foldl((\acc::String usg::Decorated Usage -> acc ++ " " ++ usg.graphviz_name ++ " " ++ foldl((\acc::String decl::Decorated Declaration -> acc ++ " " ++ usg.graphviz_name ++ " -> " ++ decl.graphviz_name), "", usg.resolutions)), "", snd(both)) ++ " }"
       end ++ "\n"
     ),
     "",

--- a/grammars/scopegraph/Draw.sv
+++ b/grammars/scopegraph/Draw.sv
@@ -132,16 +132,23 @@ String ::= paths::[Decorated Path]
 function graphviz_draw_paths
 String ::= graph::Decorated Graph
 {
-  return foldl(
-    (\acc::String cur_scope::Decorated Scope -> acc ++ 
-      let 
-        both::Pair<[Decorated Usage] [Decorated Usage]> = partition((\usg::Decorated Usage -> length(usg.resolutions) == 1), map((\usg::(String, Decorated Usage) -> snd(usg)), cur_scope.references ++ cur_scope.imports))
-      in 
-        "{edge [arrowhead=normal color=blue style=dashed]" ++ foldl((\acc::String usg::Decorated Usage -> acc ++ " " ++ usg.graphviz_name ++ " -> " ++ head(usg.resolutions).graphviz_name), "", fst(both)) ++ " }" ++ 
-        "{node [color=red shape=box fontsize=12] edge [arrowhead=normal color=red style=dashed]" ++ foldl((\acc::String usg::Decorated Usage -> acc ++ " " ++ usg.graphviz_name ++ " " ++ foldl((\acc::String decl::Decorated Declaration -> acc ++ " " ++ usg.graphviz_name ++ " -> " ++ decl.graphviz_name), "", usg.resolutions)), "", snd(both)) ++ " }"
-      end ++ "\n"
-    ),
-    "",
-    graph.scope_list
-  );
+  return 
+
+  let all::([Decorated Usage], [Decorated Usage]) = 
+    foldl(
+      (\acc::([Decorated Usage], [Decorated Usage]) cur_scope::Decorated Scope -> let new_pair::([Decorated Usage], [Decorated Usage]) = 
+          partition((\usg::Decorated Usage -> length(usg.resolutions) == 1), nubBy((\left::Decorated Usage right::Decorated Usage -> left.to_string == right.to_string), map((\usg::(String, Decorated Usage) -> snd(usg)), cur_scope.references ++ cur_scope.imports))) in (fst(acc) ++ fst(new_pair), snd(acc) ++ snd(new_pair)) end),
+      ([],[]),
+      graph.scope_list
+    )
+  in
+    "{edge [arrowhead=normal color=blue style=dashed]" ++ 
+      foldl((\acc::String usg::Decorated Usage -> acc ++ " " ++ usg.graphviz_name ++ " -> " ++ head(usg.resolutions).graphviz_name), "", nubBy((\left::Decorated Usage right::Decorated Usage -> left.to_string == right.to_string), fst(all))) ++ "}" ++
+    "{node [color=red shape=box fontsize=12] edge [arrowhead=normal color=red style=dashed]" ++
+      foldl((\acc::String usg::Decorated Usage -> acc ++ " " ++ usg.graphviz_name ++ " " ++ 
+        foldl((\acc::String decl::Decorated Declaration -> acc ++ " " ++ usg.graphviz_name ++ 
+          " -> " ++ decl.graphviz_name), "", usg.resolutions)), "", nubBy((\left::Decorated Usage right::Decorated Usage -> left.to_string == right.to_string), snd(all))) ++ "}"
+  end ++ "\n"
+  
+  ;
 }

--- a/grammars/scopegraph/Error.sv
+++ b/grammars/scopegraph/Error.sv
@@ -3,10 +3,11 @@ grammar scopegraph;
 ----------------
 -- Errors:
 
-nonterminal Error<a> with message, all_messages;
+nonterminal Error<a> with message, all_messages, resolved_to<a>;
 
 synthesized attribute message::String;
 synthesized attribute all_messages::String;
+synthesized attribute resolved_to<a>::[Decorated Declaration<a>];
 
 @{-
  - The error constructed when multiple declaration nodes are found when resolving a reference.
@@ -14,10 +15,11 @@ synthesized attribute all_messages::String;
  - @param usage The reference node for which multiple declarations are found.
 -}
 abstract production multiple_declarations_found
-top::Error<a> ::= usage::Usage<a>
+top::Error<a> ::= usage::Decorated Usage<a> resolved_to::[Decorated Declaration<a>]
 {
   top.message = "Multiple declarations found that match reference for: " ++ usage.identifier ++ 
     " at line: " ++ toString(usage.line) ++ " col: " ++ toString(usage.column);
+  top.resolved_to = resolved_to;
 }
 
 @{-
@@ -26,10 +28,11 @@ top::Error<a> ::= usage::Usage<a>
  - @param usage The reference node for which no declarations are found.
 -}
 abstract production no_declaration_found
-top::Error<a> ::= usage::Usage<a>
+top::Error<a> ::= usage::Decorated Usage<a>
 {
   top.message = "No declaration found that matches reference for: " ++ usage.identifier ++ 
     " at line: " ++ toString(usage.line) ++ " col: " ++ toString(usage.column);
+  top.resolved_to = [];
 }
 
 @{-

--- a/grammars/scopegraph/Error.sv
+++ b/grammars/scopegraph/Error.sv
@@ -3,11 +3,11 @@ grammar scopegraph;
 ----------------
 -- Errors:
 
-nonterminal Error<a> with message, all_messages, resolved_to<a>;
+nonterminal Error with message, all_messages, resolved_to;
 
 synthesized attribute message::String;
 synthesized attribute all_messages::String;
-synthesized attribute resolved_to<a>::[Decorated Declaration<a>];
+synthesized attribute resolved_to::[Decorated Declaration];
 
 @{-
  - The error constructed when multiple declaration nodes are found when resolving a reference.
@@ -15,7 +15,7 @@ synthesized attribute resolved_to<a>::[Decorated Declaration<a>];
  - @param usage The reference node for which multiple declarations are found.
 -}
 abstract production multiple_declarations_found
-top::Error<a> ::= usage::Decorated Usage<a> resolved_to::[Decorated Declaration<a>]
+top::Error ::= usage::Decorated Usage resolved_to::[Decorated Declaration]
 {
   top.message = "Multiple declarations found that match reference for: " ++ usage.identifier ++ 
     " at line: " ++ toString(usage.line) ++ " col: " ++ toString(usage.column);
@@ -28,7 +28,7 @@ top::Error<a> ::= usage::Decorated Usage<a> resolved_to::[Decorated Declaration<
  - @param usage The reference node for which no declarations are found.
 -}
 abstract production no_declaration_found
-top::Error<a> ::= usage::Decorated Usage<a>
+top::Error ::= usage::Decorated Usage
 {
   top.message = "No declaration found that matches reference for: " ++ usage.identifier ++ 
     " at line: " ++ toString(usage.line) ++ " col: " ++ toString(usage.column);
@@ -41,7 +41,7 @@ top::Error<a> ::= usage::Decorated Usage<a>
  - @param declaration The declaration node that no references are found for. 
 -}
 abstract production declaration_unused
-top::Error<a> ::= declaration::Decorated Declaration<a>
+top::Error ::= declaration::Decorated Declaration
 {
   top.message = "Declaration never used: " ++ declaration.identifier ++ 
     " at line: " ++ toString(declaration.line) ++ ", col: " ++ toString(declaration.column);
@@ -54,7 +54,7 @@ top::Error<a> ::= declaration::Decorated Declaration<a>
  - @return The string representing all errors found.
 -}
 function string_errors
-String ::= list::[Decorated Error<a>]
+String ::= list::[Decorated Error]
 {
   return case list of 
   | h::t -> "ERROR: " ++ h.message ++ "\n" ++ string_errors(t)

--- a/grammars/scopegraph/Refactor.sv
+++ b/grammars/scopegraph/Refactor.sv
@@ -1,0 +1,70 @@
+grammar scopegraph;
+
+------------------------------------------------------------
+---- Utility functions
+------------------------------------------------------------
+
+@{-
+ - Find a declaration node through searching by index.
+ -
+ - @param sought_index The declaration index to search for.
+ - @param graph The scope graph to search in.
+ - @return Either a declaration with a matching index, or nothing.
+-}
+function find_declaration_by_id
+Maybe<Decorated Declaration> ::= 
+  sought_index::String
+  graph::Decorated Graph
+{
+  return let matching_decls::[Decorated Declaration] = 
+    filter((\decl::Decorated Declaration -> decl.to_string == sought_index),
+      foldl((\acc::[Decorated Declaration] scope::Decorated Scope -> acc ++ scope.declarations), 
+        [], graph.scope_list))
+  in if length(matching_decls) >= 1 then just(head(matching_decls)) else nothing() end; -- TODO: error checking on more than 1 matching decl
+}
+
+@{-
+ - Find a list of references which resolve to a declaration.
+ -
+ - @param sought_decl The decoration our references should resolve to.
+ - @param current_scope The scope to start looking in (initially, the scope sought_decl resides in).
+ - @return A list of all references which resolve to decl.
+-}
+function find_all_references_for_decl
+[Decorated Usage] ::=
+  sought_decl::Decorated Declaration
+  current_scope::Decorated Scope
+{
+  -- collect from current_scope
+  local attribute immediate_refs::[Decorated Usage] = foldl(
+    (\acc::[Decorated Usage] ref::Decorated Usage -> 
+      acc ++ if ref.identifier == sought_decl.identifier then [ref] else []), 
+    [], current_scope.references);
+
+  -- collect from child scopes of current_scope
+  local attribute child_scope_refs::[Decorated Usage] = foldl(
+    (\acc::[Decorated Usage] child::Decorated Scope -> 
+      acc ++ find_all_references_for_decl(sought_decl, child)),
+    [], current_scope.child_scopes);
+
+  -- get scopes that import current_scope
+  local attribute parent_children::[Decorated Scope] = case current_scope.assoc_decl of
+    | nothing() -> []
+    | just(d) -> case current_scope.parent of
+      | nothing() -> []
+      | just(s) -> filter((\child::Decorated Scope -> foldl(
+        (\acc::Boolean imp::Decorated Usage -> head(imp.resolutions).to_string == d.to_string), 
+        false, child.imports)), s.child_scopes)
+    end 
+  end;
+
+  local attribute importing_refs::[Decorated Usage] = foldl(
+    (\acc::[Decorated Usage] scope::Decorated Scope -> acc ++ find_all_references_for_decl(sought_decl, scope)),
+    [], parent_children);
+
+  return if containsBy((\left::Decorated Declaration right::Decorated Declaration -> 
+      left.identifier == right.identifier && left.to_string != right.to_string),
+    sought_decl, current_scope.declarations) -- May need to change later for type-dependency of languages
+  then []
+  else immediate_refs ++ child_scope_refs ++ importing_refs;
+}

--- a/grammars/scopegraph/Resolve.sv
+++ b/grammars/scopegraph/Resolve.sv
@@ -17,8 +17,7 @@ function resolve
 {
   -- Check for any matching declarations in the current scope
   local attribute decls::[Decorated Declaration] = 
-    filter((\decl::Decorated Declaration -> decl.identifier == ref.identifier), 
-      map((\decl::(String, Decorated Declaration) -> snd(decl)), cur_scope.declarations));
+    filter((\decl::Decorated Declaration -> decl.identifier == ref.identifier), cur_scope.declarations);
 
   -- Check any imports that exist, call resolve on them
   local attribute imps::[Decorated Declaration] = foldl(
@@ -28,8 +27,7 @@ function resolve
     foldl(
       (\acc::[Decorated Declaration] cur::Decorated Usage -> acc ++ cur.resolutions),
       [],
-      filter((\imp::Decorated Usage -> imp.identifier != ref.identifier),
-        map((\decl::(String, Decorated Usage) -> snd(decl)), cur_scope.imports))
+      filter((\imp::Decorated Usage -> imp.identifier != ref.identifier), cur_scope.imports)
     )
   );
   

--- a/grammars/scopegraph/Resolve.sv
+++ b/grammars/scopegraph/Resolve.sv
@@ -1,14 +1,7 @@
 grammar scopegraph;
 
-{-
-  TODO: In the case of resolution errors - draw the problems onto the scope graph - i.e.
-  if there are multiple declarations for a reference, draw the resolution path to them in red,
-  and perhaps the reference and declarations in red. Similar thing for no declarations found,
-  just draw the reference in red?
--}
-
 ---------------
--- New resolution algorithm:
+-- Resolution algorithm:
 
 @{-
  - Resolves a reference to a set of declarations by first checking the immediate scope for

--- a/grammars/scopegraph/Scope.sv
+++ b/grammars/scopegraph/Scope.sv
@@ -4,12 +4,12 @@ grammar scopegraph;
 ----------------
 -- Scope Graph
 
-synthesized attribute scope_list<a>::[Decorated Scope<a>];
-synthesized attribute paths<a>::[Decorated Path<a>];
-synthesized attribute all_decls<a>::[Decorated Declaration<a>];
-synthesized attribute errors<a>::[Decorated Error<a>];
+synthesized attribute scope_list::[Decorated Scope];
+synthesized attribute paths::[Decorated Path];
+synthesized attribute all_decls::[Decorated Declaration];
+synthesized attribute errors::[Decorated Error];
 
-nonterminal Graph<a> with scope_list<a>, paths<a>, all_decls<a>, errors<a>;
+nonterminal Graph with scope_list, paths, all_decls, errors;
 
 @{-
  - Constructing a graph node.
@@ -17,16 +17,16 @@ nonterminal Graph<a> with scope_list<a>, paths<a>, all_decls<a>, errors<a>;
  - @param scope_list The list of scopes the graph contains.
 -}
 abstract production cons_graph
-top::Graph<a> ::= scope_list::[Decorated Scope<a>] 
-  paths::[Decorated Path<a>]
+top::Graph ::= scope_list::[Decorated Scope] 
+  paths::[Decorated Path]
 {
   top.scope_list = scope_list;
   top.paths = paths;
   top.all_decls = foldl(
-    (\all_decls::[Decorated Declaration<a>] scope::Decorated Scope<a> 
-      -> all_decls ++ map((\pair::(String, Decorated Declaration<a>) -> snd(pair)), scope.declarations)), 
+    (\all_decls::[Decorated Declaration] scope::Decorated Scope 
+      -> all_decls ++ map((\pair::(String, Decorated Declaration) -> snd(pair)), scope.declarations)), 
     [], scope_list);
-  top.errors = foldl((\acc::[Decorated Error<a>] scope::Decorated Scope<a> -> acc ++ scope.errors), [], scope_list);
+  top.errors = foldl((\acc::[Decorated Error] scope::Decorated Scope -> acc ++ scope.errors), [], scope_list);
 }
 
 
@@ -34,17 +34,17 @@ top::Graph<a> ::= scope_list::[Decorated Scope<a>]
 -- Scopes
 
 synthesized attribute id::Integer;
-synthesized attribute parent<a>::Maybe<Decorated Scope<a>>;
-synthesized attribute declarations<a>::[(String, Decorated Declaration<a>)]; -- pair of identifier name and node
-synthesized attribute references<a>::[(String, Decorated Usage<a>)];
-synthesized attribute imports<a>::[(String, Decorated Usage<a>)];
+synthesized attribute parent::Maybe<Decorated Scope>;
+synthesized attribute declarations::[(String, Decorated Declaration)]; -- pair of identifier name and node
+synthesized attribute references::[(String, Decorated Usage)];
+synthesized attribute imports::[(String, Decorated Usage)];
 synthesized attribute to_string::String;
 synthesized attribute graphviz_name::String;
 
-synthesized attribute child_scopes<a>::[Decorated Scope<a>];
+synthesized attribute child_scopes::[Decorated Scope];
 
 
-nonterminal Scope<a> with id, parent<a>, declarations<a>, references<a>, imports<a>, to_string, child_scopes<a>, errors<a>, graphviz_name;
+nonterminal Scope with id, parent, declarations, references, imports, to_string, child_scopes, errors, graphviz_name;
 
 @{-
  - Constructing a scope node.
@@ -55,11 +55,11 @@ nonterminal Scope<a> with id, parent<a>, declarations<a>, references<a>, imports
  - @param imports The list of imports attached to a node.
 -}
 abstract production cons_scope
-top::Scope<a> ::= parent::Maybe<Decorated Scope<a>> 
-  declarations::[(String, Decorated Declaration<a>)] 
-  references::[(String, Decorated Usage<a>)] 
-  imports::[(String, Decorated Usage<a>)]
-  child_scopes::[Decorated Scope<a>]
+top::Scope ::= parent::Maybe<Decorated Scope> 
+  declarations::[(String, Decorated Declaration)] 
+  references::[(String, Decorated Usage)] 
+  imports::[(String, Decorated Usage)]
+  child_scopes::[Decorated Scope]
 {
   top.id = genInt();
   top.parent = parent;
@@ -70,28 +70,28 @@ top::Scope<a> ::= parent::Maybe<Decorated Scope<a>>
   top.graphviz_name = top.to_string;
   top.child_scopes = child_scopes;
   
-  top.errors = foldl((\acc::[Decorated Error<a>] ref::Decorated Usage<a> -> acc ++ 
+  top.errors = foldl((\acc::[Decorated Error] ref::Decorated Usage -> acc ++ 
     if (length(ref.resolutions) < 1) then
       [decorate_nd_error(ref)]
     else if (length(ref.resolutions) > 1) then
       [decorate_md_error(ref, ref.resolutions)]
     else
       []
-  ), [], map((\ref::(String, Decorated Usage<a>) -> snd(ref)), references ++ imports));
+  ), [], map((\ref::(String, Decorated Usage) -> snd(ref)), references ++ imports));
 
 }
 
 function decorate_nd_error
-Decorated Error<a> ::= ref::Decorated Usage<a>
+Decorated Error ::= ref::Decorated Usage
 {
-  local attribute err::Error<a> = no_declaration_found(ref);
+  local attribute err::Error = no_declaration_found(ref);
   return err;
 }
 
 function decorate_md_error
-Decorated Error<a> ::= ref::Decorated Usage<a> resolutions::[Decorated Declaration<a>]
+Decorated Error ::= ref::Decorated Usage resolutions::[Decorated Declaration]
 {
-  local attribute err::Error<a> = multiple_declarations_found(ref, resolutions);
+  local attribute err::Error = multiple_declarations_found(ref, resolutions);
   return err;
 }
 
@@ -100,12 +100,12 @@ Decorated Error<a> ::= ref::Decorated Usage<a> resolutions::[Decorated Declarati
 -- Declarations
 
 synthesized attribute identifier::String; -- Name of the declaration
-synthesized attribute in_scope<a>::Decorated Scope<a>; -- Scope in which the declaration resides
-synthesized attribute assoc_scope<a>::Maybe<Decorated Scope<a>>; -- Scope that this declaration points to (for imports)
+synthesized attribute in_scope::Decorated Scope; -- Scope in which the declaration resides
+synthesized attribute assoc_scope::Maybe<Decorated Scope>; -- Scope that this declaration points to (for imports)
 synthesized attribute line::Integer;
 synthesized attribute column::Integer;
 
-nonterminal Declaration<a> with identifier, in_scope<a>, assoc_scope<a>, line, column, to_string, graphviz_name;
+nonterminal Declaration with identifier, in_scope, assoc_scope, line, column, to_string, graphviz_name;
 
 @{-
  - Constructing a declaration node.
@@ -117,9 +117,9 @@ nonterminal Declaration<a> with identifier, in_scope<a>, assoc_scope<a>, line, c
  - @param column The column this declaration was found on.
 -}
 abstract production cons_decl
-top::Declaration<a> ::= identifier::String 
-  in_scope::Decorated Scope<a> 
-  assoc_scope::Maybe<Decorated Scope<a>> 
+top::Declaration ::= identifier::String 
+  in_scope::Decorated Scope 
+  assoc_scope::Maybe<Decorated Scope> 
   line::Integer column::Integer
 {
   top.identifier = identifier;
@@ -133,9 +133,9 @@ top::Declaration<a> ::= identifier::String
 
 abstract production cons_decl_ref
 attribute line i occurs on a, attribute column i occurs on a =>
-top::Declaration<a> ::= identifier::String 
-  in_scope::Decorated Scope<a> 
-  assoc_scope::Maybe<Decorated Scope<a>> 
+top::Declaration ::= identifier::String 
+  in_scope::Decorated Scope 
+  assoc_scope::Maybe<Decorated Scope> 
   ast_node::Decorated a with i
 {
   top.identifier = identifier;
@@ -151,9 +151,9 @@ top::Declaration<a> ::= identifier::String
 ----------------
 -- Imports/References
 
-synthesized attribute resolutions<a>::[Decorated Declaration<a>]; -- The node that this import points to with an invisible line. added to after resolution
+synthesized attribute resolutions::[Decorated Declaration]; -- The node that this import points to with an invisible line. added to after resolution
 
-nonterminal Usage<a> with identifier, in_scope<a>, resolutions<a>, line, column, to_string, graphviz_name;
+nonterminal Usage with identifier, in_scope, resolutions, line, column, to_string, graphviz_name;
 
 @{-
  - Constructing a usage (reference/import) node.
@@ -164,8 +164,8 @@ nonterminal Usage<a> with identifier, in_scope<a>, resolutions<a>, line, column,
  - @param column The column this usage was found on.
 -}
 abstract production cons_usage
-top::Usage<a> ::= identifier::String 
-  in_scope::Decorated Scope<a> 
+top::Usage ::= identifier::String 
+  in_scope::Decorated Scope 
   line::Integer 
   column::Integer
 {

--- a/grammars/scopegraph/Scope.sv
+++ b/grammars/scopegraph/Scope.sv
@@ -40,11 +40,11 @@ synthesized attribute references::[Decorated Usage];
 synthesized attribute imports::[Decorated Usage];
 synthesized attribute to_string::String;
 synthesized attribute graphviz_name::String;
-
 synthesized attribute child_scopes::[Decorated Scope];
+synthesized attribute assoc_decl::Maybe<Decorated Declaration>;
 
 
-nonterminal Scope with id, parent, declarations, references, imports, to_string, child_scopes, errors, graphviz_name;
+nonterminal Scope with id, parent, declarations, references, imports, to_string, child_scopes, errors, graphviz_name, assoc_decl;
 
 @{-
  - Constructing a scope node.
@@ -53,6 +53,7 @@ nonterminal Scope with id, parent, declarations, references, imports, to_string,
  - @param declarations The list of declarations attached to a node.
  - @param references The list of references attached to a node.
  - @param imports The list of imports attached to a node.
+ - @param assoc_decl In the case of the declarations from a scope being imported, this points to the declarations whose associated scope is this scope.
 -}
 abstract production cons_scope
 top::Scope ::= parent::Maybe<Decorated Scope> 
@@ -60,6 +61,7 @@ top::Scope ::= parent::Maybe<Decorated Scope>
   references::[Decorated Usage] 
   imports::[Decorated Usage]
   child_scopes::[Decorated Scope]
+  assoc_decl::Maybe<Decorated Declaration>
 {
   top.id = genInt();
   top.parent = parent;
@@ -69,6 +71,7 @@ top::Scope ::= parent::Maybe<Decorated Scope>
   top.to_string = toString(top.id);
   top.graphviz_name = top.to_string;
   top.child_scopes = child_scopes;
+  top.assoc_decl = assoc_decl;
   
   top.errors = foldl((\acc::[Decorated Error] ref::Decorated Usage -> acc ++ 
     if (length(ref.resolutions) < 1) then

--- a/grammars/scopegraph/Scope.sv
+++ b/grammars/scopegraph/Scope.sv
@@ -39,11 +39,12 @@ synthesized attribute declarations<a>::[(String, Decorated Declaration<a>)]; -- 
 synthesized attribute references<a>::[(String, Decorated Usage<a>)];
 synthesized attribute imports<a>::[(String, Decorated Usage<a>)];
 synthesized attribute to_string::String;
+synthesized attribute graphviz_name::String;
 
 synthesized attribute child_scopes<a>::[Decorated Scope<a>];
 
 
-nonterminal Scope<a> with id, parent<a>, declarations<a>, references<a>, imports<a>, to_string, child_scopes<a>, errors<a>;
+nonterminal Scope<a> with id, parent<a>, declarations<a>, references<a>, imports<a>, to_string, child_scopes<a>, errors<a>, graphviz_name;
 
 @{-
  - Constructing a scope node.
@@ -66,6 +67,7 @@ top::Scope<a> ::= parent::Maybe<Decorated Scope<a>>
   top.references = references;
   top.imports = imports;
   top.to_string = toString(top.id);
+  top.graphviz_name = top.to_string;
   top.child_scopes = child_scopes;
   
   top.errors = foldl((\acc::[Decorated Error<a>] ref::Decorated Usage<a> -> acc ++ 
@@ -103,7 +105,7 @@ synthesized attribute assoc_scope<a>::Maybe<Decorated Scope<a>>; -- Scope that t
 synthesized attribute line::Integer;
 synthesized attribute column::Integer;
 
-nonterminal Declaration<a> with identifier, in_scope<a>, assoc_scope<a>, line, column, to_string;
+nonterminal Declaration<a> with identifier, in_scope<a>, assoc_scope<a>, line, column, to_string, graphviz_name;
 
 @{-
  - Constructing a declaration node.
@@ -125,7 +127,8 @@ top::Declaration<a> ::= identifier::String
   top.assoc_scope = assoc_scope;
   top.line = line;
   top.column = column;
-  top.to_string = top.identifier ++ "_" ++ toString(line) ++ "_" ++ toString(column);
+  top.to_string = top.identifier ++ "_[" ++ toString(line) ++ ", " ++ toString(column) ++ "]";
+  top.graphviz_name = "\"" ++ top.to_string ++ "\"";
 }
 
 abstract production cons_decl_ref
@@ -140,7 +143,8 @@ top::Declaration<a> ::= identifier::String
   top.assoc_scope = assoc_scope;
   top.line = ast_node.line;
   top.column = ast_node.column;
-  top.to_string = top.identifier ++ "_" ++ toString(ast_node.line) ++ "_" ++ toString(ast_node.column);
+  top.to_string = top.identifier ++ "_[" ++ toString(ast_node.line) ++ ", " ++ toString(ast_node.column) ++ "]";
+  top.graphviz_name = "\"" ++ top.to_string ++ "\"";
 }
 
 
@@ -149,7 +153,7 @@ top::Declaration<a> ::= identifier::String
 
 synthesized attribute resolutions<a>::[Decorated Declaration<a>]; -- The node that this import points to with an invisible line. added to after resolution
 
-nonterminal Usage<a> with identifier, in_scope<a>, resolutions<a>, line, column, to_string;
+nonterminal Usage<a> with identifier, in_scope<a>, resolutions<a>, line, column, to_string, graphviz_name;
 
 @{-
  - Constructing a usage (reference/import) node.
@@ -170,5 +174,6 @@ top::Usage<a> ::= identifier::String
   top.resolutions = resolve(top, in_scope);
   top.line = line;
   top.column = column;
-  top.to_string = top.identifier ++ "_" ++ toString(line) ++ "_" ++ toString(column);
+  top.to_string = top.identifier ++ "_[" ++ toString(line) ++ ", " ++ toString(column) ++ "]";
+  top.graphviz_name = "\"" ++ top.to_string ++ "\"";
 }

--- a/grammars/scopegraph/Scope.sv
+++ b/grammars/scopegraph/Scope.sv
@@ -24,7 +24,7 @@ top::Graph ::= scope_list::[Decorated Scope]
   --top.paths = paths;
   top.all_decls = foldl(
     (\all_decls::[Decorated Declaration] scope::Decorated Scope 
-      -> all_decls ++ map((\pair::(String, Decorated Declaration) -> snd(pair)), scope.declarations)), 
+      -> all_decls ++ scope.declarations), 
     [], scope_list);
   top.errors = foldl((\acc::[Decorated Error] scope::Decorated Scope -> acc ++ scope.errors), [], scope_list);
 }
@@ -35,9 +35,9 @@ top::Graph ::= scope_list::[Decorated Scope]
 
 synthesized attribute id::Integer;
 synthesized attribute parent::Maybe<Decorated Scope>;
-synthesized attribute declarations::[(String, Decorated Declaration)]; -- pair of identifier name and node
-synthesized attribute references::[(String, Decorated Usage)];
-synthesized attribute imports::[(String, Decorated Usage)];
+synthesized attribute declarations::[Decorated Declaration]; -- pair of identifier name and node
+synthesized attribute references::[Decorated Usage];
+synthesized attribute imports::[Decorated Usage];
 synthesized attribute to_string::String;
 synthesized attribute graphviz_name::String;
 
@@ -56,9 +56,9 @@ nonterminal Scope with id, parent, declarations, references, imports, to_string,
 -}
 abstract production cons_scope
 top::Scope ::= parent::Maybe<Decorated Scope> 
-  declarations::[(String, Decorated Declaration)] 
-  references::[(String, Decorated Usage)] 
-  imports::[(String, Decorated Usage)]
+  declarations::[Decorated Declaration] 
+  references::[Decorated Usage] 
+  imports::[Decorated Usage]
   child_scopes::[Decorated Scope]
 {
   top.id = genInt();
@@ -77,7 +77,7 @@ top::Scope ::= parent::Maybe<Decorated Scope>
       [decorate_md_error(ref, ref.resolutions)]
     else
       []
-  ), [], map((\ref::(String, Decorated Usage) -> snd(ref)), references ++ imports));
+  ), [], references ++ imports);
 
 }
 

--- a/grammars/scopegraph/Scope.sv
+++ b/grammars/scopegraph/Scope.sv
@@ -68,7 +68,7 @@ top::Scope<a> ::= parent::Maybe<Decorated Scope<a>>
   top.to_string = toString(top.id);
   top.child_scopes = child_scopes;
   
-  top.errors = foldl((\acc::[Decorated Error<a>] ref::Decorated Usage<a> -> 
+  top.errors = foldl((\acc::[Decorated Error<a>] ref::Decorated Usage<a> -> acc ++ 
     if (length(ref.resolutions) < 1) then
       [decorate_nd_error(ref)]
     else if (length(ref.resolutions) > 1) then

--- a/grammars/scopegraph/Scope.sv
+++ b/grammars/scopegraph/Scope.sv
@@ -5,11 +5,11 @@ grammar scopegraph;
 -- Scope Graph
 
 synthesized attribute scope_list::[Decorated Scope];
-synthesized attribute paths::[Decorated Path];
+--synthesized attribute paths::[Decorated Path];
 synthesized attribute all_decls::[Decorated Declaration];
 synthesized attribute errors::[Decorated Error];
 
-nonterminal Graph with scope_list, paths, all_decls, errors;
+nonterminal Graph with scope_list, all_decls, errors;
 
 @{-
  - Constructing a graph node.
@@ -18,10 +18,10 @@ nonterminal Graph with scope_list, paths, all_decls, errors;
 -}
 abstract production cons_graph
 top::Graph ::= scope_list::[Decorated Scope] 
-  paths::[Decorated Path]
+  --paths::[Decorated Path]
 {
   top.scope_list = scope_list;
-  top.paths = paths;
+  --top.paths = paths;
   top.all_decls = foldl(
     (\all_decls::[Decorated Declaration] scope::Decorated Scope 
       -> all_decls ++ map((\pair::(String, Decorated Declaration) -> snd(pair)), scope.declarations)), 

--- a/scripts/buildminijava.sh
+++ b/scripts/buildminijava.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+#silver -I ../grammars $@ old-stlc-wip
+
+mkdir -p ../bin
+
+silver -I ../grammars --onejar $@ minijava
+
+rm build.xml > /dev/null 2>&1
+rm Parser_minijava_parse.copperdump.html > /dev/null 2>&1
+
+mv *.jar ../bin > /dev/null 2>&1


### PR DESCRIPTION
This includes the small lambda calculus example and the modification to the scope graphs library to use 2 parameters - one for AST declarations nodes and the other for reference node.